### PR TITLE
feat: implement session detection on launch (Issue #25)

### DIFF
--- a/.config/detekt/detekt.yml
+++ b/.config/detekt/detekt.yml
@@ -44,3 +44,7 @@ style:
     active: true
     ignoreAnnotated:
       - 'Preview'
+
+Compose:
+  ViewModelForwarding:
+    active: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,11 @@ Este documento define el contexto, las reglas y las directrices arquitectónicas
 - **Detekt**: El código debe pasar el análisis estático sin errores. Ejecuta `./gradlew detekt` para verificar la calidad del código y detectar code smells.
 - Estos checks se ejecutan automáticamente en el pipeline de CI/CD para cada Pull Request a la rama `master`.
 
+### 7. Testing Automático
+- **Obligatoriedad**: Siempre que se cree o modifique un **ViewModel**, **UseCase** o **Repository**, es estrictamente obligatorio escribir o actualizar sus pruebas unitarias correspondientes en `commonTest` (o en su source set correspondiente si es código específico de plataforma).
+- **Fakes vs Mocks**: Fomenta el uso de implementaciones _Fake_ de las interfaces en lugar de librerías de _Mocking_ cuando sea posible, para mantener las pruebas robustas y fácilmente portables en KMP.
+- **Corrutinas**: Usa `kotlinx-coroutines-test` (`runTest`, `UnconfinedTestDispatcher`) y `Turbine` para probar `Flow` y `StateFlow`.
+
 ## 🎭 Roles de Agentes
 
 Cuando se te asigne una tarea en este proyecto, adopta uno de los siguientes enfoques según el contexto:

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -141,6 +141,7 @@ android {
 
 dependencies {
     debugImplementation(libs.compose.uiTooling)
+    detektPlugins(libs.detekt.compose.rules)
 }
 
 compose.desktop {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -92,6 +92,8 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.turbine)
         }
         jvmMain.dependencies {
             implementation(compose.desktop.currentOs)

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/App.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/App.kt
@@ -14,6 +14,6 @@ fun App() {
 
 @Composable
 @Preview
-fun AppPreview() {
+private fun AppPreview() {
     App()
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/repository/AuthRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/repository/AuthRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package dev.saragones3.genogramia.data.repository
+
+import dev.saragones3.genogramia.data.firebase.FirebaseProvider
+import dev.saragones3.genogramia.domain.model.User
+import dev.saragones3.genogramia.domain.repository.AuthRepository
+
+internal class AuthRepositoryImpl(
+    private val firebaseProvider: FirebaseProvider,
+) : AuthRepository {
+    override fun getCurrentUser(): User? =
+        firebaseProvider.getCurrentUser()?.let { User(it.uid, it.email, it.displayName) }
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
@@ -1,27 +1,33 @@
 package dev.saragones3.genogramia.di
 
+import dev.saragones3.genogramia.data.repository.AuthRepositoryImpl
+import dev.saragones3.genogramia.domain.repository.AuthRepository
+import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
 import dev.saragones3.genogramia.presentation.authenticatedhome.AuthenticatedHomeViewModel
 import dev.saragones3.genogramia.presentation.guesthome.GuestHomeViewModel
 import dev.saragones3.genogramia.presentation.legends.LegendsViewModel
 import dev.saragones3.genogramia.presentation.login.LoginViewModel
 import dev.saragones3.genogramia.presentation.registration.RegistrationViewModel
 import dev.saragones3.genogramia.presentation.settings.SettingsViewModel
+import dev.saragones3.genogramia.presentation.splash.SplashViewModel
 import org.koin.core.module.Module
+import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
-val dataModule =
+private val dataModule =
     module {
-        // TODO: Add repository implementations, Ktor
+        single<AuthRepository> { AuthRepositoryImpl(get()) }
     }
 
-val domainModule =
+private val domainModule =
     module {
-        // TODO: Add Use Cases
+        factoryOf(::CheckSessionUseCase)
     }
 
-val appModule =
+private val appModule =
     module {
+        viewModelOf(::SplashViewModel)
         viewModelOf(::GuestHomeViewModel)
         viewModelOf(::AuthenticatedHomeViewModel)
         viewModelOf(::LegendsViewModel)

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/model/User.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/model/User.kt
@@ -1,0 +1,7 @@
+package dev.saragones3.genogramia.domain.model
+
+data class User(
+    val uid: String,
+    val email: String?,
+    val displayName: String?,
+)

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/repository/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/repository/AuthRepository.kt
@@ -1,0 +1,7 @@
+package dev.saragones3.genogramia.domain.repository
+
+import dev.saragones3.genogramia.domain.model.User
+
+interface AuthRepository {
+    fun getCurrentUser(): User?
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/CheckSessionUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/CheckSessionUseCase.kt
@@ -1,0 +1,10 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.User
+import dev.saragones3.genogramia.domain.repository.AuthRepository
+
+class CheckSessionUseCase(
+    private val authRepository: AuthRepository,
+) {
+    operator fun invoke(): User? = authRepository.getCurrentUser()
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/authenticatedhome/AuthenticatedHomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/authenticatedhome/AuthenticatedHomeScreen.kt
@@ -49,7 +49,7 @@ fun AuthenticatedHomeScreen() {
 
 @Composable
 @Preview
-fun AuthenticatedHomeScreenPreview() {
+private fun AuthenticatedHomeScreenPreview() {
     MaterialTheme {
         AuthenticatedHomeScreen()
     }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/guesthome/GuestHomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/guesthome/GuestHomeScreen.kt
@@ -355,7 +355,7 @@ private fun GuestHomeStartTreeCard(onCreateTree: () -> Unit) {
     }
 }
 
-fun Modifier.dashedBorder(
+private fun Modifier.dashedBorder(
     width: Dp,
     color: Color,
     shape: Shape,
@@ -386,7 +386,7 @@ fun Modifier.dashedBorder(
 
 @Preview
 @Composable
-fun GuestHomeScreenPreview() {
+private fun GuestHomeScreenPreview() {
     GenogramiaTheme {
         GuestHomeScreen(
             onLoginClick = {},

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/guesthome/GuestHomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/guesthome/GuestHomeScreen.kt
@@ -155,7 +155,16 @@ private fun GuestHomeSearchBar() {
     TextField(
         value = searchQuery,
         onValueChange = { searchQuery = it },
-        modifier = Modifier.fillMaxWidth(),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .drawBehind {
+                    drawRect(
+                        color = Color.LightGray.copy(alpha = 0.3f),
+                        style = Stroke(width = 1.dp.toPx()),
+                    )
+                },
         placeholder = {
             Text(
                 text = stringResource(Res.string.search_records),
@@ -171,12 +180,12 @@ private fun GuestHomeSearchBar() {
                 modifier = Modifier.size(24.dp),
             )
         },
-        shape = CircleShape,
+        shape = RoundedCornerShape(16.dp),
         singleLine = true,
         colors =
             TextFieldDefaults.colors(
-                focusedContainerColor = MaterialTheme.colorScheme.background,
-                unfocusedContainerColor = MaterialTheme.colorScheme.background,
+                focusedContainerColor = Color(0xFFF2F2F2),
+                unfocusedContainerColor = Color(0xFFF2F2F2),
                 focusedIndicatorColor = Color.Transparent,
                 unfocusedIndicatorColor = Color.Transparent,
                 disabledIndicatorColor = Color.Transparent,

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavGraph.kt
@@ -17,6 +17,8 @@ import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateList
@@ -32,19 +34,22 @@ import dev.saragones3.genogramia.presentation.legends.LegendsScreen
 import dev.saragones3.genogramia.presentation.login.LoginScreen
 import dev.saragones3.genogramia.presentation.registration.RegistrationScreen
 import dev.saragones3.genogramia.presentation.settings.SettingsScreen
+import dev.saragones3.genogramia.presentation.splash.SplashScreen
+import dev.saragones3.genogramia.presentation.splash.SplashViewModel
 import dev.saragones3.genogramia.ui.theme.NavigationBarIndicator
 import genogramia.composeapp.generated.resources.Res
 import genogramia.composeapp.generated.resources.nav_legends
 import genogramia.composeapp.generated.resources.nav_settings
 import genogramia.composeapp.generated.resources.nav_trees
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun AppNavGraph() {
-    val backStack = rememberNavBackStack(initialKey = NavRoute.GuestHome)
+    val backStack = rememberNavBackStack(initialKey = NavRoute.Splash)
 
     val currentRoute = backStack.lastOrNull()
-    val isGuestMode = backStack.firstOrNull() is NavRoute.GuestHome
+    val isGuestMode = backStack.firstOrNull { it !is NavRoute.Splash } is NavRoute.GuestHome
 
     val showBottomBar =
         currentRoute is NavRoute.GuestHome ||
@@ -155,6 +160,22 @@ fun AppNavGraph() {
             modifier = Modifier.fillMaxSize().padding(padding),
         ) { key ->
             when (key) {
+                is NavRoute.Splash -> {
+                    val viewModel: SplashViewModel = koinViewModel()
+                    val uiState by viewModel.uiState.collectAsState()
+
+                    SplashScreen(
+                        uiState = uiState,
+                        onNavigateToGuestHome = {
+                            backStack.clear()
+                            backStack.add(NavRoute.GuestHome)
+                        },
+                        onNavigateToAuthenticatedHome = {
+                            backStack.clear()
+                            backStack.add(NavRoute.AuthenticatedHome)
+                        },
+                    )
+                }
                 is NavRoute.GuestHome -> {
                     GuestHomeScreen(
                         onLoginClick = { backStack.push(NavRoute.Login) },

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavRoute.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavRoute.kt
@@ -5,6 +5,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 sealed interface NavRoute {
     @Serializable
+    data object Splash : NavRoute
+
+    @Serializable
     data object GuestHome : NavRoute
 
     @Serializable

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/splash/SplashScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/splash/SplashScreen.kt
@@ -1,0 +1,46 @@
+package dev.saragones3.genogramia.presentation.splash
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import dev.saragones3.genogramia.ui.theme.GenogramiaTheme
+
+@Composable
+fun SplashScreen(
+    uiState: SplashUiState,
+    onNavigateToGuestHome: () -> Unit,
+    onNavigateToAuthenticatedHome: () -> Unit,
+) {
+    LaunchedEffect(uiState) {
+        when (uiState) {
+            SplashUiState.Loading -> { /* Keep showing splash */ }
+            SplashUiState.NavigateToGuestHome -> onNavigateToGuestHome()
+            SplashUiState.NavigateToAuthenticatedHome -> onNavigateToAuthenticatedHome()
+        }
+    }
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+@Preview
+private fun SplashScreenPreview() {
+    GenogramiaTheme {
+        SplashScreen(
+            uiState = SplashUiState.Loading,
+            onNavigateToGuestHome = {},
+            onNavigateToAuthenticatedHome = {},
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/splash/SplashUiState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/splash/SplashUiState.kt
@@ -1,0 +1,9 @@
+package dev.saragones3.genogramia.presentation.splash
+
+sealed interface SplashUiState {
+    data object Loading : SplashUiState
+
+    data object NavigateToGuestHome : SplashUiState
+
+    data object NavigateToAuthenticatedHome : SplashUiState
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/splash/SplashViewModel.kt
@@ -1,0 +1,26 @@
+package dev.saragones3.genogramia.presentation.splash
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+
+class SplashViewModel(
+    private val checkSession: CheckSessionUseCase,
+) : ViewModel() {
+    val uiState: StateFlow<SplashUiState> =
+        flow {
+            emit(SplashUiState.Loading)
+            val user = checkSession()
+            emit(
+                if (user != null) {
+                    SplashUiState.NavigateToAuthenticatedHome
+                } else {
+                    SplashUiState.NavigateToGuestHome
+                },
+            )
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, SplashUiState.Loading)
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/data/repository/AuthRepositoryImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/data/repository/AuthRepositoryImplTest.kt
@@ -1,0 +1,34 @@
+package dev.saragones3.genogramia.data.repository
+
+import dev.saragones3.genogramia.data.firebase.AuthUser
+import dev.saragones3.genogramia.data.firebase.FirebaseProvider
+import dev.saragones3.genogramia.fakes.FakeFirebaseProvider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AuthRepositoryImplTest {
+
+    @Test
+    fun `getCurrentUser returns mapped User when FirebaseProvider has user`() {
+        val authUser = AuthUser("uid456", "test@test.com", "John Doe")
+        val fakeProvider = FakeFirebaseProvider(authUser)
+        val repository = AuthRepositoryImpl(fakeProvider)
+
+        val result = repository.getCurrentUser()
+
+        assertEquals("uid456", result?.uid)
+        assertEquals("test@test.com", result?.email)
+        assertEquals("John Doe", result?.displayName)
+    }
+
+    @Test
+    fun `getCurrentUser returns null when FirebaseProvider has no user`() {
+        val fakeProvider = FakeFirebaseProvider(null)
+        val repository = AuthRepositoryImpl(fakeProvider)
+
+        val result = repository.getCurrentUser()
+
+        assertNull(result)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/CheckSessionUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/CheckSessionUseCaseTest.kt
@@ -1,0 +1,31 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.User
+import dev.saragones3.genogramia.domain.repository.AuthRepository
+import dev.saragones3.genogramia.fakes.FakeAuthRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CheckSessionUseCaseTest {
+    @Test
+    fun `invoke returns User when repository has a current user`() {
+        val user = User("uid123", "test@test.com", "Test User")
+        val fakeRepository = FakeAuthRepository(user)
+        val useCase = CheckSessionUseCase(fakeRepository)
+
+        val result = useCase()
+
+        assertEquals(user, result)
+    }
+
+    @Test
+    fun `invoke returns null when repository has no current user`() {
+        val fakeRepository = FakeAuthRepository(null)
+        val useCase = CheckSessionUseCase(fakeRepository)
+
+        val result = useCase()
+
+        assertNull(result)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeAuthRepository.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeAuthRepository.kt
@@ -1,0 +1,12 @@
+package dev.saragones3.genogramia.fakes
+
+import dev.saragones3.genogramia.domain.model.User
+import dev.saragones3.genogramia.domain.repository.AuthRepository
+
+class FakeAuthRepository(private var currentUser: User? = null) : AuthRepository {
+    override fun getCurrentUser(): User? = currentUser
+
+    fun setCurrentUser(user: User?) {
+        currentUser = user
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeFirebaseProvider.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeFirebaseProvider.kt
@@ -1,0 +1,36 @@
+package dev.saragones3.genogramia.fakes
+
+import dev.saragones3.genogramia.data.firebase.AuthUser
+import dev.saragones3.genogramia.data.firebase.FirebaseProvider
+
+class FakeFirebaseProvider(private var currentUser: AuthUser? = null) : FirebaseProvider {
+    override fun getCurrentUser(): AuthUser? = currentUser
+
+    override suspend fun createUserWithEmailAndPassword(email: String, password: String): AuthUser {
+        throw NotImplementedError()
+    }
+
+    override suspend fun signInWithEmailAndPassword(email: String, password: String): AuthUser {
+        throw NotImplementedError()
+    }
+
+    override suspend fun sendPasswordResetEmail(email: String) {
+        throw NotImplementedError()
+    }
+
+    override suspend fun updatePassword(newPassword: String) {
+        throw NotImplementedError()
+    }
+
+    override suspend fun signOut() {
+        currentUser = null
+    }
+
+    override suspend fun deleteCurrentUser() {
+        currentUser = null
+    }
+
+    fun setCurrentUser(user: AuthUser?) {
+        currentUser = user
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/splash/SplashViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/splash/SplashViewModelTest.kt
@@ -1,0 +1,55 @@
+package dev.saragones3.genogramia.presentation.splash
+
+import app.cash.turbine.test
+import dev.saragones3.genogramia.domain.model.User
+import dev.saragones3.genogramia.domain.repository.AuthRepository
+import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
+import dev.saragones3.genogramia.fakes.FakeAuthRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SplashViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `when user is logged in, navigates to AuthenticatedHome`() = runTest {
+        val fakeRepo = FakeAuthRepository(User("uid", "email", "name"))
+        val useCase = CheckSessionUseCase(fakeRepo)
+        val viewModel = SplashViewModel(useCase)
+
+        viewModel.uiState.test {
+            assertEquals(SplashUiState.NavigateToAuthenticatedHome, awaitItem())
+        }
+    }
+
+    @Test
+    fun `when user is not logged in, navigates to GuestHome`() = runTest {
+        val fakeRepo = FakeAuthRepository(null)
+        val useCase = CheckSessionUseCase(fakeRepo)
+        val viewModel = SplashViewModel(useCase)
+
+        viewModel.uiState.test {
+            assertEquals(SplashUiState.NavigateToGuestHome, awaitItem())
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ material3 = "1.9.0"
 navigation3 = "1.1.0"
 spotless = "7.0.2"
 detekt = "1.23.8"
+compose-rules = "0.4.22"
 koin = "4.1.1"
 firebase = "33.14.0"
 google-services = "4.4.2"
@@ -54,6 +55,7 @@ koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase" }
 firebase-auth-android = { module = "com.google.firebase:firebase-auth" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines" }
+detekt-compose-rules = { module = "io.nlopez.compose.rules:detekt", version.ref = "compose-rules" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ spotless = "7.0.2"
 detekt = "1.23.8"
 compose-rules = "0.4.22"
 koin = "4.1.1"
+turbine = "1.1.0"
 firebase = "33.14.0"
 google-services = "4.4.2"
 
@@ -55,6 +56,8 @@ koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase" }
 firebase-auth-android = { module = "com.google.firebase:firebase-auth" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 detekt-compose-rules = { module = "io.nlopez.compose.rules:detekt", version.ref = "compose-rules" }
 
 [plugins]


### PR DESCRIPTION
This PR implements US-001 (Issue #25) for session detection upon application launch.

Key changes:
- Created Splash screen with ViewModel and UiState.
- Implemented Clean Architecture: User model, AuthRepository (AuthRepositoryImpl), and CheckSessionUseCase.
- Integrated Koin for DI of the new components.
- Configured NavGraph to start with Splash and navigate to GuestHome or AuthenticatedHome based on session state.
- Added detekt compose-rules with ViewModelForwarding check.
- Refactored visibilities (previews and internal helpers made private) as per AGENTS.md.
- Adjusted GuestHomeSearchBar styling to match US-009 design.

Quality checks:
- Passed spotlessApply and detekt.