### PR TITLE
Fix login crash and refactor to use SignInUseCase

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -41,6 +41,7 @@
     <string name="login_guest_label">Acceso como invitado</string>
     <string name="login_create_account_label">Crear cuenta</string>
     <string name="error_invalid_credentials">Credenciales inválidas</string>
+    <string name="error_user_not_found">La cuenta no existe</string>
     <string name="error_empty_credentials">Debes introducir correo y contraseña</string>
     
     <!-- Registration -->

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="login_guest_label">Guest access</string>
     <string name="login_create_account_label">Create account</string>
     <string name="error_invalid_credentials">Invalid credentials</string>
+    <string name="error_user_not_found">Account does not exist</string>
     <string name="error_empty_credentials">You must enter an email and password</string>
     
     <!-- Registration -->

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
@@ -4,6 +4,7 @@ import dev.saragones3.genogramia.data.repository.AuthRepositoryImpl
 import dev.saragones3.genogramia.domain.repository.AuthRepository
 import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
 import dev.saragones3.genogramia.domain.usecase.DeleteAccountUseCase
+import dev.saragones3.genogramia.domain.usecase.SignInUseCase
 import dev.saragones3.genogramia.domain.usecase.SignOutUseCase
 import dev.saragones3.genogramia.domain.usecase.SignUpUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdatePasswordUseCase
@@ -28,6 +29,7 @@ private val domainModule =
     module {
         factoryOf(::CheckSessionUseCase)
         factoryOf(::SignUpUseCase)
+        factoryOf(::SignInUseCase)
         factoryOf(::SignOutUseCase)
         factoryOf(::DeleteAccountUseCase)
         factoryOf(::UpdatePasswordUseCase)

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/model/AuthError.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/model/AuthError.kt
@@ -1,6 +1,6 @@
 package dev.saragones3.genogramia.domain.model
 
-sealed class AuthError : Throwable() {
+sealed class AuthError : Exception() {
     data object EmailAlreadyInUse : AuthError()
 
     data object InvalidEmail : AuthError()

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/SignInUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/SignInUseCase.kt
@@ -1,0 +1,16 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.User
+import dev.saragones3.genogramia.domain.repository.AuthRepository
+
+class SignInUseCase(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke(
+        email: String,
+        password: String,
+    ): Result<User> =
+        runCatching {
+            authRepository.signInWithEmailAndPassword(email, password)
+        }
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/login/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/login/LoginScreen.kt
@@ -70,6 +70,7 @@ import genogramia.composeapp.generated.resources.error_empty_fields
 import genogramia.composeapp.generated.resources.error_invalid_credentials
 import genogramia.composeapp.generated.resources.error_invalid_email
 import genogramia.composeapp.generated.resources.error_invalid_password
+import genogramia.composeapp.generated.resources.error_user_not_found
 import genogramia.composeapp.generated.resources.login_button
 import genogramia.composeapp.generated.resources.login_create_account_label
 import genogramia.composeapp.generated.resources.login_email_hint
@@ -100,6 +101,7 @@ fun LoginScreen(
     val snackbarHostState = remember { SnackbarHostState() }
 
     val invalidCredentialsStr = stringResource(Res.string.error_invalid_credentials)
+    val userNotFoundStr = stringResource(Res.string.error_user_not_found)
 
     LaunchedEffect(uiState.isSuccess) {
         if (uiState.isSuccess) {
@@ -113,6 +115,7 @@ fun LoginScreen(
             val message =
                 when (error) {
                     LoginError.WrongCredentials -> invalidCredentialsStr
+                    LoginError.UserNotFound -> userNotFoundStr
                 }
             snackbarHostState.showSnackbar(message)
             onErrorShown()

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/login/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/login/LoginScreen.kt
@@ -91,6 +91,7 @@ fun LoginScreen(
     onDataChange: (String, String) -> Unit,
     onLoginClick: () -> Unit,
     onErrorShown: () -> Unit,
+    onLoginSuccessConsumed: () -> Unit,
     onBackClick: () -> Unit,
     onLoginSuccess: () -> Unit,
     onRegisterClick: () -> Unit,
@@ -103,6 +104,7 @@ fun LoginScreen(
     LaunchedEffect(uiState.isSuccess) {
         if (uiState.isSuccess) {
             onLoginSuccess()
+            onLoginSuccessConsumed()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/login/LoginUiState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/login/LoginUiState.kt
@@ -17,4 +17,5 @@ data class LoginUiState(
 
 enum class LoginError {
     WrongCredentials,
+    UserNotFound,
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/login/LoginViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/login/LoginViewModel.kt
@@ -2,7 +2,8 @@ package dev.saragones3.genogramia.presentation.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import dev.saragones3.genogramia.domain.repository.AuthRepository
+import dev.saragones3.genogramia.domain.model.AuthError
+import dev.saragones3.genogramia.domain.usecase.SignInUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -10,7 +11,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class LoginViewModel(
-    private val authRepository: AuthRepository,
+    private val signInUseCase: SignInUseCase,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(LoginUiState())
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
@@ -38,12 +39,19 @@ class LoginViewModel(
 
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, generalError = null) }
-            try {
-                authRepository.signInWithEmailAndPassword(email, password)
-                _uiState.update { it.copy(isLoading = false, isSuccess = true) }
-            } catch (_: Exception) {
-                _uiState.update { it.copy(isLoading = false, generalError = LoginError.WrongCredentials) }
-            }
+            val result = signInUseCase(email, password)
+
+            result
+                .onSuccess {
+                    _uiState.update { it.copy(isLoading = false, isSuccess = true) }
+                }.onFailure { error ->
+                    val loginError =
+                        when (error) {
+                            is AuthError.UserNotFound -> LoginError.UserNotFound
+                            else -> LoginError.WrongCredentials
+                        }
+                    _uiState.update { it.copy(isLoading = false, generalError = loginError) }
+                }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/login/LoginViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/login/LoginViewModel.kt
@@ -81,6 +81,10 @@ class LoginViewModel(
         return emailRegex.matches(email)
     }
 
+    fun loginSuccessConsumed() {
+        _uiState.value = LoginUiState()
+    }
+
     fun errorShown() {
         _uiState.update { it.copy(generalError = null) }
     }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavGraph.kt
@@ -198,6 +198,7 @@ fun AppNavGraph() {
                         onDataChange = viewModel::onDataChange,
                         onLoginClick = viewModel::login,
                         onErrorShown = viewModel::errorShown,
+                        onLoginSuccessConsumed = viewModel::loginSuccessConsumed,
                         onBackClick = { backStack.pop() },
                         onLoginSuccess = {
                             backStack.clear()
@@ -225,6 +226,7 @@ fun AppNavGraph() {
                     SettingsScreen(
                         state = state,
                         onEvent = viewModel::onEvent,
+                        onLogoutConsumed = viewModel::logoutConsumed,
                         onChangePasswordClick = {
                             backStack.push(NavRoute.ChangePassword)
                         },
@@ -248,6 +250,7 @@ fun AppNavGraph() {
                     RegistrationScreen(
                         state = state,
                         onEvent = viewModel::onEvent,
+                        onRegistrationSuccessConsumed = viewModel::registrationSuccessConsumed,
                         onBackClick = { backStack.pop() },
                         onRegistrationSuccess = {
                             backStack.clear()

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/registration/RegistrationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/registration/RegistrationScreen.kt
@@ -89,12 +89,14 @@ import org.jetbrains.compose.resources.stringResource
 fun RegistrationScreen(
     state: RegistrationState,
     onEvent: (RegistrationEvent) -> Unit,
+    onRegistrationSuccessConsumed: () -> Unit,
     onBackClick: () -> Unit,
     onRegistrationSuccess: () -> Unit,
 ) {
     LaunchedEffect(state.isRegistrationSuccess) {
         if (state.isRegistrationSuccess) {
             onRegistrationSuccess()
+            onRegistrationSuccessConsumed()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/registration/RegistrationViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/registration/RegistrationViewModel.kt
@@ -120,4 +120,8 @@ class RegistrationViewModel(
         val emailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[a-z]+$".toRegex()
         return emailRegex.matches(email)
     }
+
+    fun registrationSuccessConsumed() {
+        _state.value = RegistrationState()
+    }
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/SettingsScreen.kt
@@ -67,12 +67,14 @@ import org.jetbrains.compose.resources.stringResource
 fun SettingsScreen(
     state: SettingsState,
     onEvent: (SettingsEvent) -> Unit,
+    onLogoutConsumed: () -> Unit,
     onChangePasswordClick: () -> Unit,
     onLoggedOut: () -> Unit,
 ) {
     LaunchedEffect(state.isLoggedOut) {
         if (state.isLoggedOut) {
             onLoggedOut()
+            onLogoutConsumed()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/SettingsViewModel.kt
@@ -59,4 +59,8 @@ class SettingsViewModel(
             }
         }
     }
+
+    fun logoutConsumed() {
+        _state.update { it.copy(isLoggedOut = false) }
+    }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/DeleteAccountUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/DeleteAccountUseCaseTest.kt
@@ -1,0 +1,22 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.fakes.FakeAuthRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+class DeleteAccountUseCaseTest {
+    private val repository = FakeAuthRepository()
+    private val deleteAccountUseCase = DeleteAccountUseCase(repository)
+
+    @Test
+    fun `when delete account is called then repository delete account is called`() =
+        runTest {
+            // Set a user first
+            repository.signInWithEmailAndPassword("test@test.com", "password")
+
+            deleteAccountUseCase()
+
+            assertNull(repository.getCurrentUser())
+        }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/SignInUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/SignInUseCaseTest.kt
@@ -1,0 +1,39 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.fakes.FakeAuthRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SignInUseCaseTest {
+    private val repository = FakeAuthRepository()
+    private val signInUseCase = SignInUseCase(repository)
+
+    @Test
+    fun `when signin is successful returns success with user`() =
+        runTest {
+            val email = "test@example.com"
+            val password = "password123"
+
+            val result = signInUseCase(email, password)
+
+            assertTrue(result.isSuccess)
+            val user = result.getOrNull()
+            assertEquals(email, user?.email)
+        }
+
+    @Test
+    fun `when signin fails returns failure`() =
+        runTest {
+            repository.shouldReturnError = true
+            repository.errorToReturn = Exception("Fake signin error")
+            val email = "test@example.com"
+            val password = "password123"
+
+            val result = signInUseCase(email, password)
+
+            assertTrue(result.isFailure)
+            assertEquals("Fake signin error", result.exceptionOrNull()?.message)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/SignOutUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/SignOutUseCaseTest.kt
@@ -1,0 +1,22 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.fakes.FakeAuthRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+class SignOutUseCaseTest {
+    private val repository = FakeAuthRepository()
+    private val signOutUseCase = SignOutUseCase(repository)
+
+    @Test
+    fun `when signout is called then repository signout is called`() =
+        runTest {
+            // Set a user first
+            repository.signInWithEmailAndPassword("test@test.com", "password")
+
+            signOutUseCase()
+
+            assertNull(repository.getCurrentUser())
+        }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/UpdatePasswordUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/UpdatePasswordUseCaseTest.kt
@@ -1,0 +1,17 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.fakes.FakeAuthRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class UpdatePasswordUseCaseTest {
+    private val repository = FakeAuthRepository()
+    private val updatePasswordUseCase = UpdatePasswordUseCase(repository)
+
+    @Test
+    fun `when update password is called then repository update password is called`() =
+        runTest {
+            // In FakeAuthRepository, updatePassword doesn't do much but we can verify it doesn't throw
+            updatePasswordUseCase("newPassword123")
+        }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/login/LoginViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/login/LoginViewModelTest.kt
@@ -1,6 +1,7 @@
 package dev.saragones3.genogramia.presentation.login
 
 import app.cash.turbine.test
+import dev.saragones3.genogramia.domain.model.AuthError
 import dev.saragones3.genogramia.fakes.FakeAuthRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -146,6 +147,61 @@ class LoginViewModelTest {
                 assertFalse(errorState.isLoading)
                 assertFalse(errorState.isSuccess)
                 assertEquals(LoginError.WrongCredentials, errorState.generalError)
+            }
+        }
+
+    @Test
+    fun login_with_non_existent_user_sets_user_not_found_error() =
+        runTest(testDispatcher) {
+            fakeAuthRepository.shouldReturnError = true
+            fakeAuthRepository.errorToReturn = AuthError.UserNotFound
+
+            viewModel.uiState.test {
+                awaitItem() // initial
+
+                viewModel.onDataChange("non-existent@test.com", "password123")
+                awaitItem()
+
+                viewModel.login()
+
+                val loadingState = awaitItem()
+                assertTrue(loadingState.isLoading)
+
+                val errorState = awaitItem()
+                assertFalse(errorState.isLoading)
+                assertEquals(LoginError.UserNotFound, errorState.generalError)
+            }
+        }
+
+    @Test
+    fun errorShown_clears_general_error() =
+        runTest(testDispatcher) {
+            fakeAuthRepository.shouldReturnError = true
+            viewModel.onDataChange("test@test.com", "password123")
+            viewModel.login()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.errorShown()
+
+            viewModel.uiState.test {
+                val state = awaitItem()
+                assertNull(state.generalError)
+            }
+        }
+
+    @Test
+    fun loginSuccessConsumed_resets_state() =
+        runTest(testDispatcher) {
+            viewModel.onDataChange("test@test.com", "password123")
+            viewModel.login()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.loginSuccessConsumed()
+
+            viewModel.uiState.test {
+                val state = awaitItem()
+                assertEquals("", state.email)
+                assertFalse(state.isSuccess)
             }
         }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/registration/RegistrationViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/registration/RegistrationViewModelTest.kt
@@ -16,6 +16,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -153,5 +154,18 @@ class RegistrationViewModelTest {
             val state = viewModel.state.value
             assertEquals(Res.string.error_email_already_in_use, state.generalError)
             assertEquals(false, state.isLoading)
+        }
+
+    @Test
+    fun `registrationSuccessConsumed resets state`() =
+        runTest {
+            viewModel.onEvent(RegistrationEvent.OnDataChanged("Test User", "test@example.com", "password123"))
+
+            viewModel.registrationSuccessConsumed()
+
+            val state = viewModel.state.value
+            assertEquals("", state.name)
+            assertEquals("", state.email)
+            assertFalse(state.isRegistrationSuccess)
         }
 }


### PR DESCRIPTION
## Summary
This PR fixes a crash occurring when logging in with a non-existent account and refactors the login logic to follow the project's architecture.

## Changes
- **Fix**: Modified `AuthError` to inherit from `Exception` instead of `Throwable` so it can be caught by standard try-catch blocks.
- **Architecture**: Introduced `SignInUseCase` to separate business logic from the `LoginViewModel`.
- **UX**: Added a specific error message for "User Not Found" (Account does not exist) in both Spanish and English.
- **DI**: Updated Koin configuration to include the new UseCase.
- **Testing**: Added unit tests for `SignInUseCase`, `SignOutUseCase`, `DeleteAccountUseCase`, and `UpdatePasswordUseCase`. Updated `LoginViewModelTest` and `RegistrationViewModelTest` with additional scenarios.

## Verification
- Ran `./gradlew spotlessApply` and `./gradlew detekt`.
- Verified that unit tests in `commonTest` are passing.