### PR TITLE
Fix: Reauthentication before password change and field cleanup

### DIFF
--- a/composeApp/src/androidMain/kotlin/dev/saragones3/genogramia/data/error/ErrorMapper.kt
+++ b/composeApp/src/androidMain/kotlin/dev/saragones3/genogramia/data/error/ErrorMapper.kt
@@ -3,6 +3,7 @@ package dev.saragones3.genogramia.data.error
 import com.google.firebase.auth.FirebaseAuthException
 import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
 import com.google.firebase.auth.FirebaseAuthInvalidUserException
+import com.google.firebase.auth.FirebaseAuthRecentLoginRequiredException
 import com.google.firebase.auth.FirebaseAuthUserCollisionException
 import com.google.firebase.auth.FirebaseAuthWeakPasswordException
 import dev.saragones3.genogramia.domain.model.AuthError
@@ -25,9 +26,14 @@ actual fun Throwable.toAuthError(): AuthError =
             AuthError.UserNotFound
         }
 
+        is FirebaseAuthRecentLoginRequiredException -> {
+            AuthError.RequiresRecentLogin
+        }
+
         is FirebaseAuthException -> {
             when (errorCode) {
                 "ERROR_WRONG_PASSWORD" -> AuthError.WrongPassword
+                "ERROR_REQUIRES_RECENT_LOGIN" -> AuthError.RequiresRecentLogin
                 else -> AuthError.Unknown
             }
         }

--- a/composeApp/src/androidMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseProviderImpl.kt
+++ b/composeApp/src/androidMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseProviderImpl.kt
@@ -1,5 +1,6 @@
 package dev.saragones3.genogramia.data.firebase
 
+import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.userProfileChangeRequest
@@ -32,6 +33,17 @@ internal class FirebaseProviderImpl : FirebaseProvider {
         } catch (e: Exception) {
             throw e.toAuthError()
         }
+
+    override suspend fun reauthenticate(password: String) {
+        try {
+            val user = auth.currentUser ?: return
+            val email = user.email ?: return
+            val credential = EmailAuthProvider.getCredential(email, password)
+            user.reauthenticate(credential).await()
+        } catch (e: Exception) {
+            throw e.toAuthError()
+        }
+    }
 
     override suspend fun sendPasswordResetEmail(email: String) {
         try {

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -87,8 +87,13 @@
 
     <!-- Change Password -->
     <string name="change_password_title">Cambiar Contraseña</string>
+    <string name="change_password_settings">Ajustes</string>
+    <string name="change_password_subtitle">Actualiza tus credenciales para mantener tu archivo familiar seguro y protegido.</string>
+    <string name="change_password_data_protection_title">Protección de Datos</string>
+    <string name="change_password_data_protection_desc">Usa al menos 8 caracteres para una mayor seguridad.</string>
     <string name="change_password_new_label">NUEVA CONTRASEÑA</string>
     <string name="change_password_confirm_label">CONFIRMAR NUEVA CONTRASEÑA</string>
+    <string name="change_password_forgot">¿HAS OLVIDADO TU CONTRASEÑA?</string>
     <string name="change_password_save">Guardar Contraseña</string>
     <string name="change_password_success">Contraseña actualizada con éxito</string>
     <string name="error_passwords_do_not_match">Las contraseñas no coinciden</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -87,8 +87,13 @@
 
     <!-- Change Password -->
     <string name="change_password_title">Change Password</string>
+    <string name="change_password_settings">Settings</string>
+    <string name="change_password_subtitle">Update your credentials to keep your family archive safe and protected.</string>
+    <string name="change_password_data_protection_title">Data Protection</string>
+    <string name="change_password_data_protection_desc">Use at least 8 characters for enhanced security.</string>
     <string name="change_password_new_label">NEW PASSWORD</string>
     <string name="change_password_confirm_label">CONFIRM NEW PASSWORD</string>
+    <string name="change_password_forgot">FORGOT YOUR PASSWORD?</string>
     <string name="change_password_save">Save Password</string>
     <string name="change_password_success">Password updated successfully</string>
     <string name="error_passwords_do_not_match">Passwords do not match</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -92,6 +92,7 @@
     <string name="change_password_data_protection_title">Data Protection</string>
     <string name="change_password_data_protection_desc">Use at least 8 characters for enhanced security.</string>
     <string name="change_password_new_label">NEW PASSWORD</string>
+    <string name="change_password_current_label">CURRENT PASSWORD</string>
     <string name="change_password_confirm_label">CONFIRM NEW PASSWORD</string>
     <string name="change_password_forgot">FORGOT YOUR PASSWORD?</string>
     <string name="change_password_save">Save Password</string>

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseProvider.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseProvider.kt
@@ -16,6 +16,8 @@ interface FirebaseProvider {
         password: String,
     ): AuthUser
 
+    suspend fun reauthenticate(password: String)
+
     suspend fun sendPasswordResetEmail(email: String)
 
     suspend fun updatePassword(newPassword: String)

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/repository/AuthRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/repository/AuthRepositoryImpl.kt
@@ -32,6 +32,10 @@ internal class AuthRepositoryImpl(
         firebaseProvider.signOut()
     }
 
+    override suspend fun reauthenticate(password: String) {
+        firebaseProvider.reauthenticate(password)
+    }
+
     override suspend fun deleteAccount() {
         firebaseProvider.deleteCurrentUser()
     }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
@@ -13,6 +13,7 @@ import dev.saragones3.genogramia.presentation.guesthome.GuestHomeViewModel
 import dev.saragones3.genogramia.presentation.legends.LegendsViewModel
 import dev.saragones3.genogramia.presentation.login.LoginViewModel
 import dev.saragones3.genogramia.presentation.registration.RegistrationViewModel
+import dev.saragones3.genogramia.presentation.settings.ChangePasswordViewModel
 import dev.saragones3.genogramia.presentation.settings.SettingsViewModel
 import dev.saragones3.genogramia.presentation.splash.SplashViewModel
 import org.koin.core.module.Module
@@ -44,6 +45,7 @@ private val appModule =
         viewModelOf(::LoginViewModel)
         viewModelOf(::RegistrationViewModel)
         viewModelOf(::SettingsViewModel)
+        viewModelOf(::ChangePasswordViewModel)
     }
 
 fun getSharedModules(): List<Module> =

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/model/AuthError.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/model/AuthError.kt
@@ -11,5 +11,7 @@ sealed class AuthError : Exception() {
 
     data object WrongPassword : AuthError()
 
+    data object RequiresRecentLogin : AuthError()
+
     data object Unknown : AuthError()
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/repository/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/repository/AuthRepository.kt
@@ -18,6 +18,8 @@ interface AuthRepository {
 
     suspend fun signOut()
 
+    suspend fun reauthenticate(password: String)
+
     suspend fun deleteAccount()
 
     suspend fun updatePassword(newPassword: String)

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/UpdatePasswordUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/UpdatePasswordUseCase.kt
@@ -5,5 +5,11 @@ import dev.saragones3.genogramia.domain.repository.AuthRepository
 class UpdatePasswordUseCase(
     private val authRepository: AuthRepository,
 ) {
-    suspend operator fun invoke(newPassword: String) = authRepository.updatePassword(newPassword)
+    suspend operator fun invoke(
+        currentPassword: String,
+        newPassword: String,
+    ) {
+        authRepository.reauthenticate(currentPassword)
+        authRepository.updatePassword(newPassword)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavGraph.kt
@@ -169,6 +169,7 @@ fun AppNavGraph() {
                         onDataChange = viewModel::onDataChange,
                         onSaveClick = viewModel::savePassword,
                         onSuccessConsumed = viewModel::successConsumed,
+                        onDispose = viewModel::clearData,
                         onBackClick = { backStack.pop() },
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavGraph.kt
@@ -36,6 +36,7 @@ import dev.saragones3.genogramia.presentation.login.LoginViewModel
 import dev.saragones3.genogramia.presentation.registration.RegistrationScreen
 import dev.saragones3.genogramia.presentation.registration.RegistrationViewModel
 import dev.saragones3.genogramia.presentation.settings.ChangePasswordScreen
+import dev.saragones3.genogramia.presentation.settings.ChangePasswordViewModel
 import dev.saragones3.genogramia.presentation.settings.SettingsScreen
 import dev.saragones3.genogramia.presentation.settings.SettingsViewModel
 import dev.saragones3.genogramia.presentation.splash.SplashScreen
@@ -64,98 +65,20 @@ fun AppNavGraph() {
     Scaffold(
         bottomBar = {
             if (showBottomBar) {
-                NavigationBar(
-                    modifier = Modifier.clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp)),
-                    containerColor = Color.White,
-                    tonalElevation = 0.dp,
-                ) {
-                    val rootRoute = if (isGuestMode) NavRoute.GuestHome else NavRoute.AuthenticatedHome
-
-                    val itemColors =
-                        NavigationBarItemDefaults.colors(
-                            selectedIconColor = MaterialTheme.colorScheme.primary,
-                            selectedTextColor = MaterialTheme.colorScheme.primary,
-                            indicatorColor = NavigationBarIndicator,
-                            unselectedIconColor = Color.Gray,
-                            unselectedTextColor = Color.Gray,
-                        )
-
-                    NavigationBarItem(
-                        selected = currentRoute is NavRoute.GuestHome || currentRoute is NavRoute.AuthenticatedHome,
-                        onClick = {
-                            if (currentRoute != rootRoute) {
-                                backStack.clear()
-                                backStack.add(rootRoute)
+                AppBottomBar(
+                    currentRoute = currentRoute,
+                    isGuestMode = isGuestMode,
+                    onNavigate = { route ->
+                        if (currentRoute != route) {
+                            backStack.clear()
+                            if (route is NavRoute.Legends || route is NavRoute.Settings) {
+                                val root = if (isGuestMode) NavRoute.GuestHome else NavRoute.AuthenticatedHome
+                                backStack.add(root)
                             }
-                        },
-                        icon = {
-                            Icon(
-                                imageVector = Icons.Default.AccountTree,
-                                contentDescription = null,
-                            )
-                        },
-                        label = {
-                            Text(
-                                text = stringResource(Res.string.nav_trees),
-                                fontSize = 10.sp,
-                                fontWeight = FontWeight.Bold,
-                            )
-                        },
-                        colors = itemColors,
-                    )
-
-                    NavigationBarItem(
-                        selected = currentRoute is NavRoute.Legends,
-                        onClick = {
-                            if (currentRoute !is NavRoute.Legends) {
-                                backStack.clear()
-                                backStack.add(rootRoute)
-                                backStack.add(NavRoute.Legends)
-                            }
-                        },
-                        icon = {
-                            Icon(
-                                imageVector = Icons.Default.AutoStories,
-                                contentDescription = null,
-                            )
-                        },
-                        label = {
-                            Text(
-                                text = stringResource(Res.string.nav_legends),
-                                fontSize = 10.sp,
-                                fontWeight = FontWeight.Bold,
-                            )
-                        },
-                        colors = itemColors,
-                    )
-
-                    if (!isGuestMode) {
-                        NavigationBarItem(
-                            selected = currentRoute is NavRoute.Settings,
-                            onClick = {
-                                if (currentRoute !is NavRoute.Settings) {
-                                    backStack.clear()
-                                    backStack.add(rootRoute)
-                                    backStack.add(NavRoute.Settings)
-                                }
-                            },
-                            icon = {
-                                Icon(
-                                    imageVector = Icons.Default.Settings,
-                                    contentDescription = null,
-                                )
-                            },
-                            label = {
-                                Text(
-                                    text = stringResource(Res.string.nav_settings),
-                                    fontSize = 10.sp,
-                                    fontWeight = FontWeight.Bold,
-                                )
-                            },
-                            colors = itemColors,
-                        )
-                    }
-                }
+                            backStack.add(route)
+                        }
+                    },
+                )
             }
         },
     ) { padding ->
@@ -238,7 +161,14 @@ fun AppNavGraph() {
                 }
 
                 is NavRoute.ChangePassword -> {
+                    val viewModel: ChangePasswordViewModel = koinViewModel()
+                    val state by viewModel.state.collectAsState()
+
                     ChangePasswordScreen(
+                        state = state,
+                        onDataChange = viewModel::onDataChange,
+                        onSaveClick = viewModel::savePassword,
+                        onSuccessConsumed = viewModel::successConsumed,
                         onBackClick = { backStack.pop() },
                     )
                 }
@@ -259,6 +189,89 @@ fun AppNavGraph() {
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun AppBottomBar(
+    currentRoute: NavRoute,
+    isGuestMode: Boolean,
+    onNavigate: (NavRoute) -> Unit,
+) {
+    NavigationBar(
+        modifier = Modifier.clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp)),
+        containerColor = Color.White,
+        tonalElevation = 0.dp,
+    ) {
+        val rootRoute = if (isGuestMode) NavRoute.GuestHome else NavRoute.AuthenticatedHome
+
+        val itemColors =
+            NavigationBarItemDefaults.colors(
+                selectedIconColor = MaterialTheme.colorScheme.primary,
+                selectedTextColor = MaterialTheme.colorScheme.primary,
+                indicatorColor = NavigationBarIndicator,
+                unselectedIconColor = Color.Gray,
+                unselectedTextColor = Color.Gray,
+            )
+
+        NavigationBarItem(
+            selected = currentRoute is NavRoute.GuestHome || currentRoute is NavRoute.AuthenticatedHome,
+            onClick = { onNavigate(rootRoute) },
+            icon = {
+                Icon(
+                    imageVector = Icons.Default.AccountTree,
+                    contentDescription = null,
+                )
+            },
+            label = {
+                Text(
+                    text = stringResource(Res.string.nav_trees),
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+            },
+            colors = itemColors,
+        )
+
+        NavigationBarItem(
+            selected = currentRoute is NavRoute.Legends,
+            onClick = { onNavigate(NavRoute.Legends) },
+            icon = {
+                Icon(
+                    imageVector = Icons.Default.AutoStories,
+                    contentDescription = null,
+                )
+            },
+            label = {
+                Text(
+                    text = stringResource(Res.string.nav_legends),
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+            },
+            colors = itemColors,
+        )
+
+        if (!isGuestMode) {
+            NavigationBarItem(
+                selected = currentRoute is NavRoute.Settings || currentRoute is NavRoute.ChangePassword,
+                onClick = { onNavigate(NavRoute.Settings) },
+                icon = {
+                    Icon(
+                        imageVector = Icons.Default.Settings,
+                        contentDescription = null,
+                    )
+                },
+                label = {
+                    Text(
+                        text = stringResource(Res.string.nav_settings),
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                },
+                colors = itemColors,
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordScreen.kt
@@ -1,48 +1,389 @@
 package dev.saragones3.genogramia.presentation.settings
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.filled.VpnKey
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import dev.saragones3.genogramia.ui.theme.GenogramiaTheme
+import dev.saragones3.genogramia.ui.theme.Primary
+import dev.saragones3.genogramia.ui.theme.SurfaceContainerHighest
+import dev.saragones3.genogramia.ui.theme.SurfaceContainerLow
 import genogramia.composeapp.generated.resources.Res
+import genogramia.composeapp.generated.resources.change_password_confirm_label
+import genogramia.composeapp.generated.resources.change_password_data_protection_desc
+import genogramia.composeapp.generated.resources.change_password_data_protection_title
+import genogramia.composeapp.generated.resources.change_password_forgot
+import genogramia.composeapp.generated.resources.change_password_new_label
+import genogramia.composeapp.generated.resources.change_password_save
+import genogramia.composeapp.generated.resources.change_password_settings
+import genogramia.composeapp.generated.resources.change_password_subtitle
+import genogramia.composeapp.generated.resources.change_password_success
 import genogramia.composeapp.generated.resources.change_password_title
 import org.jetbrains.compose.resources.stringResource
 
+@Composable
+fun ChangePasswordScreen(
+    state: ChangePasswordState,
+    onDataChange: (String, String) -> Unit,
+    onSaveClick: () -> Unit,
+    onSuccessConsumed: () -> Unit,
+    onBackClick: () -> Unit,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val successMessage = stringResource(Res.string.change_password_success)
+
+    LaunchedEffect(state.isSuccess) {
+        if (state.isSuccess) {
+            snackbarHostState.showSnackbar(successMessage)
+            onSuccessConsumed()
+        }
+    }
+
+    ChangePasswordContent(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onDataChange = onDataChange,
+        onSaveClick = onSaveClick,
+        onBackClick = onBackClick,
+    )
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ChangePasswordScreen(onBackClick: () -> Unit) {
+private fun ChangePasswordContent(
+    state: ChangePasswordState,
+    snackbarHostState: SnackbarHostState,
+    onDataChange: (String, String) -> Unit,
+    onSaveClick: () -> Unit,
+    onBackClick: () -> Unit,
+) {
     Scaffold(
+        containerColor = MaterialTheme.colorScheme.surface,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(Res.string.change_password_title)) },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                            contentDescription = null,
+            Column {
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = stringResource(Res.string.change_password_settings),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = Primary,
                         )
-                    }
-                },
-            )
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = onBackClick) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                                contentDescription = null,
+                                tint = Primary,
+                            )
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White),
+                )
+                HorizontalDivider(color = Color.LightGray.copy(alpha = 0.2f))
+            }
         },
     ) { padding ->
         Column(
-            modifier = Modifier.fillMaxSize().padding(padding),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Header Section
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
+                horizontalAlignment = Alignment.Start,
+            ) {
+                Text(
+                    text = stringResource(Res.string.change_password_title),
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = stringResource(Res.string.change_password_subtitle),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                    lineHeight = 24.sp,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(40.dp))
+
+            // Info Card
+            DataProtectionCard()
+
+            Spacer(modifier = Modifier.height(40.dp))
+
+            // Form Section
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
+            ) {
+                var newPasswordVisible by remember { mutableStateOf(false) }
+                PasswordField(
+                    label = stringResource(Res.string.change_password_new_label),
+                    value = state.newPassword,
+                    onValueChange = { onDataChange(it, state.confirmPassword) },
+                    isVisible = newPasswordVisible,
+                    onToggleVisibility = { newPasswordVisible = !newPasswordVisible },
+                    trailingIcon = Icons.Default.Lock,
+                    error = state.passwordError?.message?.let { stringResource(it) },
+                    imeAction = ImeAction.Next,
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                var confirmPasswordVisible by remember { mutableStateOf(false) }
+                PasswordField(
+                    label = stringResource(Res.string.change_password_confirm_label),
+                    value = state.confirmPassword,
+                    onValueChange = { onDataChange(state.newPassword, it) },
+                    isVisible = confirmPasswordVisible,
+                    onToggleVisibility = { confirmPasswordVisible = !confirmPasswordVisible },
+                    trailingIcon = Icons.Default.CheckCircle,
+                    error = state.confirmError?.message?.let { stringResource(it) },
+                    imeAction = ImeAction.Done,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                TextButton(
+                    onClick = { /* TODO: US-005 */ },
+                    modifier = Modifier.align(Alignment.End),
+                ) {
+                    Text(
+                        text = stringResource(Res.string.change_password_forgot),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = Primary,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(48.dp))
+
+            if (state.generalError != null) {
+                Text(
+                    text = stringResource(state.generalError),
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            // Save Button
+            Button(
+                onClick = onSaveClick,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp).height(64.dp),
+                shape = CircleShape,
+                colors = ButtonDefaults.buttonColors(containerColor = Primary),
+                enabled = !state.isLoading,
+            ) {
+                if (state.isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = stringResource(Res.string.change_password_save),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Icon(
+                            imageVector = Icons.Default.VpnKey,
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun DataProtectionCard() {
+    Surface(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
+        shape = RoundedCornerShape(24.dp),
+        color = SurfaceContainerLow,
+    ) {
+        Row(
+            modifier = Modifier.padding(24.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Surface(
+                modifier = Modifier.size(56.dp),
+                shape = CircleShape,
+                color = Primary.copy(alpha = 0.1f),
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.Default.Shield,
+                        contentDescription = null,
+                        tint = Primary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(20.dp))
+
+            Column {
+                Text(
+                    text = stringResource(Res.string.change_password_data_protection_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(Res.string.change_password_data_protection_desc),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                    lineHeight = 18.sp,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PasswordField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    isVisible: Boolean,
+    onToggleVisibility: () -> Unit,
+    trailingIcon: ImageVector,
+    error: String? = null,
+    imeAction: ImeAction = ImeAction.Default,
+) {
+    val isError = error != null
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+
+        TextField(
+            value = value,
+            onValueChange = onValueChange,
+            placeholder = { Text("........", color = Color.Gray, fontSize = 18.sp) },
+            trailingIcon = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(onClick = onToggleVisibility) {
+                        val visibilityIcon = if (isVisible) Icons.Default.Visibility else Icons.Default.VisibilityOff
+                        Icon(imageVector = visibilityIcon, contentDescription = null, tint = Color.Gray)
+                    }
+                    Icon(
+                        imageVector = trailingIcon,
+                        contentDescription = null,
+                        tint = if (isError) MaterialTheme.colorScheme.error else Color.LightGray,
+                        modifier = Modifier.padding(end = 12.dp).size(20.dp),
+                    )
+                }
+            },
+            visualTransformation = if (isVisible) VisualTransformation.None else PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = imeAction),
+            singleLine = true,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(64.dp)
+                    .clip(RoundedCornerShape(16.dp)),
+            colors =
+                TextFieldDefaults.colors(
+                    focusedContainerColor = SurfaceContainerHighest,
+                    unfocusedContainerColor = SurfaceContainerHighest,
+                    errorContainerColor = SurfaceContainerHighest,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    disabledIndicatorColor = Color.Transparent,
+                    errorIndicatorColor = Color.Transparent,
+                ),
+            isError = isError,
+        )
+        if (isError) {
             Text(
-                modifier = Modifier.padding(padding),
-                text = "Change Password Implementation Placeholder",
+                text = error!!,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.padding(top = 4.dp, start = 4.dp),
             )
         }
     }
@@ -50,8 +391,14 @@ fun ChangePasswordScreen(onBackClick: () -> Unit) {
 
 @Composable
 @Preview
-fun ChangePasswordScreenPreview() {
+private fun ChangePasswordScreenPreview() {
     GenogramiaTheme {
-        ChangePasswordScreen(onBackClick = {})
+        ChangePasswordContent(
+            state = ChangePasswordState(),
+            snackbarHostState = remember { SnackbarHostState() },
+            onDataChange = { _, _ -> },
+            onSaveClick = {},
+            onBackClick = {},
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -84,10 +85,17 @@ fun ChangePasswordScreen(
     onDataChange: (String, String, String) -> Unit,
     onSaveClick: () -> Unit,
     onSuccessConsumed: () -> Unit,
+    onDispose: () -> Unit,
     onBackClick: () -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     val successMessage = stringResource(Res.string.change_password_success)
+
+    DisposableEffect(Unit) {
+        onDispose {
+            onDispose()
+        }
+    }
 
     LaunchedEffect(state.isSuccess) {
         if (state.isSuccess) {

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordScreen.kt
@@ -66,6 +66,7 @@ import dev.saragones3.genogramia.ui.theme.SurfaceContainerHighest
 import dev.saragones3.genogramia.ui.theme.SurfaceContainerLow
 import genogramia.composeapp.generated.resources.Res
 import genogramia.composeapp.generated.resources.change_password_confirm_label
+import genogramia.composeapp.generated.resources.change_password_current_label
 import genogramia.composeapp.generated.resources.change_password_data_protection_desc
 import genogramia.composeapp.generated.resources.change_password_data_protection_title
 import genogramia.composeapp.generated.resources.change_password_forgot
@@ -80,7 +81,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun ChangePasswordScreen(
     state: ChangePasswordState,
-    onDataChange: (String, String) -> Unit,
+    onDataChange: (String, String, String) -> Unit,
     onSaveClick: () -> Unit,
     onSuccessConsumed: () -> Unit,
     onBackClick: () -> Unit,
@@ -109,7 +110,7 @@ fun ChangePasswordScreen(
 private fun ChangePasswordContent(
     state: ChangePasswordState,
     snackbarHostState: SnackbarHostState,
-    onDataChange: (String, String) -> Unit,
+    onDataChange: (String, String, String) -> Unit,
     onSaveClick: () -> Unit,
     onBackClick: () -> Unit,
 ) {
@@ -183,11 +184,25 @@ private fun ChangePasswordContent(
             Column(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
             ) {
+                var currentPasswordVisible by remember { mutableStateOf(false) }
+                PasswordField(
+                    label = stringResource(Res.string.change_password_current_label),
+                    value = state.currentPassword,
+                    onValueChange = { onDataChange(it, state.newPassword, state.confirmPassword) },
+                    isVisible = currentPasswordVisible,
+                    onToggleVisibility = { currentPasswordVisible = !currentPasswordVisible },
+                    trailingIcon = Icons.Default.Lock,
+                    error = state.currentPasswordError?.message?.let { stringResource(it) },
+                    imeAction = ImeAction.Next,
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
                 var newPasswordVisible by remember { mutableStateOf(false) }
                 PasswordField(
                     label = stringResource(Res.string.change_password_new_label),
                     value = state.newPassword,
-                    onValueChange = { onDataChange(it, state.confirmPassword) },
+                    onValueChange = { onDataChange(state.currentPassword, it, state.confirmPassword) },
                     isVisible = newPasswordVisible,
                     onToggleVisibility = { newPasswordVisible = !newPasswordVisible },
                     trailingIcon = Icons.Default.Lock,
@@ -201,7 +216,7 @@ private fun ChangePasswordContent(
                 PasswordField(
                     label = stringResource(Res.string.change_password_confirm_label),
                     value = state.confirmPassword,
-                    onValueChange = { onDataChange(state.newPassword, it) },
+                    onValueChange = { onDataChange(state.currentPassword, state.newPassword, it) },
                     isVisible = confirmPasswordVisible,
                     onToggleVisibility = { confirmPasswordVisible = !confirmPasswordVisible },
                     trailingIcon = Icons.Default.CheckCircle,
@@ -396,7 +411,7 @@ private fun ChangePasswordScreenPreview() {
         ChangePasswordContent(
             state = ChangePasswordState(),
             snackbarHostState = remember { SnackbarHostState() },
-            onDataChange = { _, _ -> },
+            onDataChange = { _, _, _ -> },
             onSaveClick = {},
             onBackClick = {},
         )

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordState.kt
@@ -1,0 +1,25 @@
+package dev.saragones3.genogramia.presentation.settings
+
+import genogramia.composeapp.generated.resources.Res
+import genogramia.composeapp.generated.resources.error_empty_fields
+import genogramia.composeapp.generated.resources.error_invalid_password
+import genogramia.composeapp.generated.resources.error_passwords_do_not_match
+import org.jetbrains.compose.resources.StringResource
+
+data class ChangePasswordState(
+    val newPassword: String = "",
+    val confirmPassword: String = "",
+    val isLoading: Boolean = false,
+    val isSuccess: Boolean = false,
+    val passwordError: ValidationError? = null,
+    val confirmError: ValidationError? = null,
+    val generalError: StringResource? = null,
+) {
+    enum class ValidationError(
+        val message: StringResource,
+    ) {
+        EMPTY(Res.string.error_empty_fields),
+        TOO_SHORT(Res.string.error_invalid_password),
+        MISMATCH(Res.string.error_passwords_do_not_match),
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordState.kt
@@ -7,10 +7,12 @@ import genogramia.composeapp.generated.resources.error_passwords_do_not_match
 import org.jetbrains.compose.resources.StringResource
 
 data class ChangePasswordState(
+    val currentPassword: String = "",
     val newPassword: String = "",
     val confirmPassword: String = "",
     val isLoading: Boolean = false,
     val isSuccess: Boolean = false,
+    val currentPasswordError: ValidationError? = null,
     val passwordError: ValidationError? = null,
     val confirmError: ValidationError? = null,
     val generalError: StringResource? = null,

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordViewModel.kt
@@ -2,8 +2,10 @@ package dev.saragones3.genogramia.presentation.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dev.saragones3.genogramia.domain.model.AuthError
 import dev.saragones3.genogramia.domain.usecase.UpdatePasswordUseCase
 import genogramia.composeapp.generated.resources.Res
+import genogramia.composeapp.generated.resources.error_invalid_credentials
 import genogramia.composeapp.generated.resources.error_unknown
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,13 +20,16 @@ class ChangePasswordViewModel(
     val state: StateFlow<ChangePasswordState> = _state.asStateFlow()
 
     fun onDataChange(
+        currentPassword: String,
         newPassword: String,
         confirmPassword: String,
     ) {
         _state.update {
             it.copy(
+                currentPassword = currentPassword,
                 newPassword = newPassword,
                 confirmPassword = confirmPassword,
+                currentPasswordError = null,
                 passwordError = null,
                 confirmError = null,
                 generalError = null,
@@ -34,6 +39,13 @@ class ChangePasswordViewModel(
 
     fun savePassword() {
         val current = _state.value
+
+        val currentPasswordError =
+            when {
+                current.currentPassword.isBlank() -> ChangePasswordState.ValidationError.EMPTY
+                else -> null
+            }
+
         val passwordError =
             when {
                 current.newPassword.isBlank() -> ChangePasswordState.ValidationError.EMPTY
@@ -48,18 +60,29 @@ class ChangePasswordViewModel(
                 else -> null
             }
 
-        if (passwordError != null || confirmError != null) {
-            _state.update { it.copy(passwordError = passwordError, confirmError = confirmError) }
+        if (currentPasswordError != null || passwordError != null || confirmError != null) {
+            _state.update {
+                it.copy(
+                    currentPasswordError = currentPasswordError,
+                    passwordError = passwordError,
+                    confirmError = confirmError,
+                )
+            }
             return
         }
 
         _state.update { it.copy(isLoading = true) }
         viewModelScope.launch {
             try {
-                updatePasswordUseCase(current.newPassword)
+                updatePasswordUseCase(current.currentPassword, current.newPassword)
                 _state.update { it.copy(isLoading = false, isSuccess = true) }
             } catch (e: Exception) {
-                _state.update { it.copy(isLoading = false, generalError = Res.string.error_unknown) }
+                val errorRes =
+                    when (e) {
+                        is AuthError.WrongPassword -> Res.string.error_invalid_credentials
+                        else -> Res.string.error_unknown
+                    }
+                _state.update { it.copy(isLoading = false, generalError = errorRes) }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordViewModel.kt
@@ -75,7 +75,15 @@ class ChangePasswordViewModel(
         viewModelScope.launch {
             try {
                 updatePasswordUseCase(current.currentPassword, current.newPassword)
-                _state.update { it.copy(isLoading = false, isSuccess = true) }
+                _state.update {
+                    it.copy(
+                        isLoading = false,
+                        isSuccess = true,
+                        currentPassword = "",
+                        newPassword = "",
+                        confirmPassword = "",
+                    )
+                }
             } catch (e: Exception) {
                 val errorRes =
                     when (e) {
@@ -89,5 +97,11 @@ class ChangePasswordViewModel(
 
     fun successConsumed() {
         _state.update { it.copy(isSuccess = false) }
+    }
+
+    fun clearData() {
+        _state.update {
+            ChangePasswordState()
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordViewModel.kt
@@ -1,0 +1,70 @@
+package dev.saragones3.genogramia.presentation.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.saragones3.genogramia.domain.usecase.UpdatePasswordUseCase
+import genogramia.composeapp.generated.resources.Res
+import genogramia.composeapp.generated.resources.error_unknown
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ChangePasswordViewModel(
+    private val updatePasswordUseCase: UpdatePasswordUseCase,
+) : ViewModel() {
+    private val _state = MutableStateFlow(ChangePasswordState())
+    val state: StateFlow<ChangePasswordState> = _state.asStateFlow()
+
+    fun onDataChange(
+        newPassword: String,
+        confirmPassword: String,
+    ) {
+        _state.update {
+            it.copy(
+                newPassword = newPassword,
+                confirmPassword = confirmPassword,
+                passwordError = null,
+                confirmError = null,
+                generalError = null,
+            )
+        }
+    }
+
+    fun savePassword() {
+        val current = _state.value
+        val passwordError =
+            when {
+                current.newPassword.isBlank() -> ChangePasswordState.ValidationError.EMPTY
+                current.newPassword.length < 8 -> ChangePasswordState.ValidationError.TOO_SHORT
+                else -> null
+            }
+
+        val confirmError =
+            when {
+                current.confirmPassword.isBlank() -> ChangePasswordState.ValidationError.EMPTY
+                current.newPassword != current.confirmPassword -> ChangePasswordState.ValidationError.MISMATCH
+                else -> null
+            }
+
+        if (passwordError != null || confirmError != null) {
+            _state.update { it.copy(passwordError = passwordError, confirmError = confirmError) }
+            return
+        }
+
+        _state.update { it.copy(isLoading = true) }
+        viewModelScope.launch {
+            try {
+                updatePasswordUseCase(current.newPassword)
+                _state.update { it.copy(isLoading = false, isSuccess = true) }
+            } catch (e: Exception) {
+                _state.update { it.copy(isLoading = false, generalError = Res.string.error_unknown) }
+            }
+        }
+    }
+
+    fun successConsumed() {
+        _state.update { it.copy(isSuccess = false) }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/UpdatePasswordUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/UpdatePasswordUseCaseTest.kt
@@ -9,9 +9,9 @@ class UpdatePasswordUseCaseTest {
     private val updatePasswordUseCase = UpdatePasswordUseCase(repository)
 
     @Test
-    fun `when update password is called then repository update password is called`() =
+    fun `when update password is called then repository reauthenticates and updates password`() =
         runTest {
             // In FakeAuthRepository, updatePassword doesn't do much but we can verify it doesn't throw
-            updatePasswordUseCase("newPassword123")
+            updatePasswordUseCase("oldPassword", "newPassword123")
         }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeAuthRepository.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeAuthRepository.kt
@@ -48,6 +48,8 @@ class FakeAuthRepository(
     }
 
     override suspend fun updatePassword(newPassword: String) {
-        // No-op for fake
+        if (shouldReturnError) {
+            throw errorToReturn
+        }
     }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeAuthRepository.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeAuthRepository.kt
@@ -43,6 +43,12 @@ class FakeAuthRepository(
         currentUser = null
     }
 
+    override suspend fun reauthenticate(password: String) {
+        if (shouldReturnError) {
+            throw errorToReturn
+        }
+    }
+
     override suspend fun deleteAccount() {
         currentUser = null
     }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/login/LoginViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/login/LoginViewModelTest.kt
@@ -2,6 +2,7 @@ package dev.saragones3.genogramia.presentation.login
 
 import app.cash.turbine.test
 import dev.saragones3.genogramia.domain.model.AuthError
+import dev.saragones3.genogramia.domain.usecase.SignInUseCase
 import dev.saragones3.genogramia.fakes.FakeAuthRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,13 +22,15 @@ import kotlin.test.assertTrue
 class LoginViewModelTest {
     private lateinit var viewModel: LoginViewModel
     private lateinit var fakeAuthRepository: FakeAuthRepository
+    private lateinit var signInUseCase: SignInUseCase
     private val testDispatcher = StandardTestDispatcher()
 
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         fakeAuthRepository = FakeAuthRepository()
-        viewModel = LoginViewModel(fakeAuthRepository)
+        signInUseCase = SignInUseCase(fakeAuthRepository)
+        viewModel = LoginViewModel(signInUseCase)
     }
 
     @AfterTest

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordViewModelTest.kt
@@ -40,8 +40,10 @@ class ChangePasswordViewModelTest {
     fun `initial state is empty`() =
         runTest {
             val state = viewModel.state.value
+            assertEquals("", state.currentPassword)
             assertEquals("", state.newPassword)
             assertEquals("", state.confirmPassword)
+            assertNull(state.currentPasswordError)
             assertNull(state.passwordError)
             assertNull(state.confirmError)
         }
@@ -52,6 +54,7 @@ class ChangePasswordViewModelTest {
             viewModel.savePassword()
 
             val state = viewModel.state.value
+            assertEquals(ChangePasswordState.ValidationError.EMPTY, state.currentPasswordError)
             assertEquals(ChangePasswordState.ValidationError.EMPTY, state.passwordError)
             assertEquals(ChangePasswordState.ValidationError.EMPTY, state.confirmError)
         }
@@ -59,7 +62,7 @@ class ChangePasswordViewModelTest {
     @Test
     fun `when passwords do not match validation fails`() =
         runTest {
-            viewModel.onDataChange("password123", "password321")
+            viewModel.onDataChange("oldPass", "password123", "password321")
             viewModel.savePassword()
 
             val state = viewModel.state.value
@@ -70,7 +73,7 @@ class ChangePasswordViewModelTest {
     @Test
     fun `when password is too short validation fails`() =
         runTest {
-            viewModel.onDataChange("short", "short")
+            viewModel.onDataChange("oldPass", "short", "short")
             viewModel.savePassword()
 
             val state = viewModel.state.value
@@ -81,7 +84,7 @@ class ChangePasswordViewModelTest {
     @Test
     fun `when update is successful success state is true`() =
         runTest {
-            viewModel.onDataChange("newPassword123", "newPassword123")
+            viewModel.onDataChange("oldPass", "newPassword123", "newPassword123")
 
             viewModel.state.test {
                 viewModel.savePassword()
@@ -106,7 +109,7 @@ class ChangePasswordViewModelTest {
     fun `when update fails general error is updated`() =
         runTest {
             repository.shouldReturnError = true
-            viewModel.onDataChange("newPassword123", "newPassword123")
+            viewModel.onDataChange("oldPass", "newPassword123", "newPassword123")
 
             viewModel.savePassword()
             testDispatcher.scheduler.advanceUntilIdle()
@@ -119,7 +122,7 @@ class ChangePasswordViewModelTest {
     @Test
     fun `successConsumed resets success state`() =
         runTest {
-            viewModel.onDataChange("newPassword123", "newPassword123")
+            viewModel.onDataChange("oldPass", "newPassword123", "newPassword123")
             viewModel.savePassword()
             testDispatcher.scheduler.advanceUntilIdle()
 

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordViewModelTest.kt
@@ -102,6 +102,9 @@ class ChangePasswordViewModelTest {
                 val finalState = awaitItem()
                 assertEquals(false, finalState.isLoading)
                 assertTrue(finalState.isSuccess)
+                assertEquals("", finalState.currentPassword)
+                assertEquals("", finalState.newPassword)
+                assertEquals("", finalState.confirmPassword)
             }
         }
 
@@ -131,5 +134,20 @@ class ChangePasswordViewModelTest {
             viewModel.successConsumed()
 
             assertEquals(false, viewModel.state.value.isSuccess)
+        }
+
+    @Test
+    fun `clearData resets all fields`() =
+        runTest {
+            viewModel.onDataChange("old", "new", "new")
+            viewModel.clearData()
+
+            val state = viewModel.state.value
+            assertEquals("", state.currentPassword)
+            assertEquals("", state.newPassword)
+            assertEquals("", state.confirmPassword)
+            assertNull(state.currentPasswordError)
+            assertNull(state.passwordError)
+            assertNull(state.confirmError)
         }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/settings/ChangePasswordViewModelTest.kt
@@ -1,0 +1,132 @@
+package dev.saragones3.genogramia.presentation.settings
+
+import app.cash.turbine.test
+import dev.saragones3.genogramia.domain.usecase.UpdatePasswordUseCase
+import dev.saragones3.genogramia.fakes.FakeAuthRepository
+import genogramia.composeapp.generated.resources.Res
+import genogramia.composeapp.generated.resources.error_unknown
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChangePasswordViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository = FakeAuthRepository()
+    private val updatePasswordUseCase = UpdatePasswordUseCase(repository)
+    private lateinit var viewModel: ChangePasswordViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = ChangePasswordViewModel(updatePasswordUseCase)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state is empty`() =
+        runTest {
+            val state = viewModel.state.value
+            assertEquals("", state.newPassword)
+            assertEquals("", state.confirmPassword)
+            assertNull(state.passwordError)
+            assertNull(state.confirmError)
+        }
+
+    @Test
+    fun `when fields are empty validation fails`() =
+        runTest {
+            viewModel.savePassword()
+
+            val state = viewModel.state.value
+            assertEquals(ChangePasswordState.ValidationError.EMPTY, state.passwordError)
+            assertEquals(ChangePasswordState.ValidationError.EMPTY, state.confirmError)
+        }
+
+    @Test
+    fun `when passwords do not match validation fails`() =
+        runTest {
+            viewModel.onDataChange("password123", "password321")
+            viewModel.savePassword()
+
+            val state = viewModel.state.value
+            assertNull(state.passwordError)
+            assertEquals(ChangePasswordState.ValidationError.MISMATCH, state.confirmError)
+        }
+
+    @Test
+    fun `when password is too short validation fails`() =
+        runTest {
+            viewModel.onDataChange("short", "short")
+            viewModel.savePassword()
+
+            val state = viewModel.state.value
+            assertEquals(ChangePasswordState.ValidationError.TOO_SHORT, state.passwordError)
+            assertNull(state.confirmError)
+        }
+
+    @Test
+    fun `when update is successful success state is true`() =
+        runTest {
+            viewModel.onDataChange("newPassword123", "newPassword123")
+
+            viewModel.state.test {
+                viewModel.savePassword()
+
+                // Skip initial state and data change state
+                var lastState = awaitItem()
+                while (lastState.newPassword != "newPassword123") {
+                    lastState = awaitItem()
+                }
+
+                // Loading state
+                assertEquals(true, awaitItem().isLoading)
+
+                // Success state
+                val finalState = awaitItem()
+                assertEquals(false, finalState.isLoading)
+                assertTrue(finalState.isSuccess)
+            }
+        }
+
+    @Test
+    fun `when update fails general error is updated`() =
+        runTest {
+            repository.shouldReturnError = true
+            viewModel.onDataChange("newPassword123", "newPassword123")
+
+            viewModel.savePassword()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertEquals(Res.string.error_unknown, state.generalError)
+            assertEquals(false, state.isLoading)
+        }
+
+    @Test
+    fun `successConsumed resets success state`() =
+        runTest {
+            viewModel.onDataChange("newPassword123", "newPassword123")
+            viewModel.savePassword()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertTrue(viewModel.state.value.isSuccess)
+
+            viewModel.successConsumed()
+
+            assertEquals(false, viewModel.state.value.isSuccess)
+        }
+}

--- a/composeApp/src/iosMain/kotlin/dev/saragones3/genogramia/data/error/ErrorMapper.kt
+++ b/composeApp/src/iosMain/kotlin/dev/saragones3/genogramia/data/error/ErrorMapper.kt
@@ -10,6 +10,7 @@ actual fun Throwable.toAuthError(): AuthError {
         msg.contains("WEAK_PASSWORD", ignoreCase = true) -> AuthError.WeakPassword
         msg.contains("USER_NOT_FOUND", ignoreCase = true) -> AuthError.UserNotFound
         msg.contains("WRONG_PASSWORD", ignoreCase = true) -> AuthError.WrongPassword
+        msg.contains("RECENT_LOGIN_REQUIRED", ignoreCase = true) -> AuthError.RequiresRecentLogin
         else -> AuthError.Unknown
     }
 }

--- a/composeApp/src/iosMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseAuthDelegate.kt
+++ b/composeApp/src/iosMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseAuthDelegate.kt
@@ -22,6 +22,12 @@ interface FirebaseAuthDelegate {
         onError: (message: String) -> Unit,
     )
 
+    fun reauthenticate(
+        password: String,
+        onSuccess: () -> Unit,
+        onError: (message: String) -> Unit,
+    )
+
     fun createUserWithEmail(
         email: String,
         password: String,

--- a/composeApp/src/iosMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseProviderImpl.kt
+++ b/composeApp/src/iosMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseProviderImpl.kt
@@ -42,6 +42,15 @@ internal class FirebaseProviderImpl(
             )
         }
 
+    override suspend fun reauthenticate(password: String): Unit =
+        suspendCancellableCoroutine { cont ->
+            delegate.reauthenticate(
+                password = password,
+                onSuccess = { cont.resumeWith(Result.success(Unit)) },
+                onError = { msg -> cont.resumeWithException(Exception(msg).toAuthError()) },
+            )
+        }
+
     override suspend fun sendPasswordResetEmail(email: String): Unit =
         suspendCancellableCoroutine { cont ->
             delegate.sendPasswordResetEmail(

--- a/composeApp/src/jvmMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseProviderImpl.kt
+++ b/composeApp/src/jvmMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseProviderImpl.kt
@@ -44,6 +44,10 @@ internal class FirebaseProviderImpl : FirebaseProvider {
         return user
     }
 
+    override suspend fun reauthenticate(password: String) {
+        delay(300)
+    }
+
     override suspend fun sendPasswordResetEmail(email: String) {
         delay(500)
     }

--- a/composeApp/src/webMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseProviderImpl.kt
+++ b/composeApp/src/webMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseProviderImpl.kt
@@ -122,7 +122,9 @@ external fun signInEmailJs(
     pass: String,
 ): Promise<JsAuthResult>
 
-@JsFun("(user, email, pass) => { const cred = window.firebaseAuthModule.EmailAuthProvider.credential(email, pass); return window.firebaseAuthModule.reauthenticateWithCredential(user, cred); }")
+@JsFun(
+    "(user, email, pass) => { const cred = window.firebaseAuthModule.EmailAuthProvider.credential(email, pass); return window.firebaseAuthModule.reauthenticateWithCredential(user, cred); }",
+)
 external fun reauthenticateJs(
     user: JsAuthUser,
     email: String,

--- a/composeApp/src/webMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseProviderImpl.kt
+++ b/composeApp/src/webMain/kotlin/dev/saragones3/genogramia/data/firebase/FirebaseProviderImpl.kt
@@ -41,6 +41,16 @@ internal class FirebaseProviderImpl : FirebaseProvider {
             throw e.toAuthError()
         }
 
+    override suspend fun reauthenticate(password: String) {
+        try {
+            val user = getCurrentUserJs() ?: throw Exception("No authenticated user")
+            val email = user.email ?: throw Exception("User has no email")
+            reauthenticateJs(user, email, password).await()
+        } catch (e: Exception) {
+            throw e.toAuthError()
+        }
+    }
+
     override suspend fun sendPasswordResetEmail(email: String) {
         try {
             sendPasswordResetJs(getAuthJs(), email).await()
@@ -111,6 +121,13 @@ external fun signInEmailJs(
     email: String,
     pass: String,
 ): Promise<JsAuthResult>
+
+@JsFun("(user, email, pass) => { const cred = window.firebaseAuthModule.EmailAuthProvider.credential(email, pass); return window.firebaseAuthModule.reauthenticateWithCredential(user, cred); }")
+external fun reauthenticateJs(
+    user: JsAuthUser,
+    email: String,
+    pass: String,
+): Promise<JsAny?>
 
 @JsFun("(auth, email) => window.firebaseAuthModule.sendPasswordResetEmail(auth, email)")
 external fun sendPasswordResetJs(


### PR DESCRIPTION
This PR addresses the 'sensitive operation' error from Firebase by requiring re-authentication before updating the password. It also adds cleanup logic for the password fields on success and when leaving the screen.

### Changes:
- Added 'Current Password' field to ChangePasswordScreen.
- Implemented eauthenticate in AuthRepository and FirebaseProvider for all platforms.
- Updated UpdatePasswordUseCase to handle the re-authentication flow.
- Added field cleanup logic on success and screen disposal.
- Updated unit tests and fakes.