### PR TITLE
feat(newtree): implement US-009 Guest user creates a temporary tree #26

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeScreen.kt
@@ -81,6 +81,7 @@ import genogramia.composeapp.generated.resources.new_tree_death_date_optional
 import genogramia.composeapp.generated.resources.new_tree_first_name_hint
 import genogramia.composeapp.generated.resources.new_tree_first_name_label
 import genogramia.composeapp.generated.resources.new_tree_footer
+import genogramia.composeapp.generated.resources.new_tree_guest_notice
 import genogramia.composeapp.generated.resources.new_tree_header_subtitle
 import genogramia.composeapp.generated.resources.new_tree_header_title
 import genogramia.composeapp.generated.resources.new_tree_last_name_hint
@@ -171,7 +172,7 @@ private fun NewTreeContent(
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            NewTreeFooter()
+            NewTreeFooter(state.isGuest)
 
             Spacer(modifier = Modifier.height(32.dp))
         }
@@ -497,11 +498,22 @@ private fun NewTreeButton(
 }
 
 @Composable
-private fun NewTreeFooter() {
+private fun NewTreeFooter(isGuest: Boolean) {
     Text(
-        text = stringResource(Res.string.new_tree_footer),
+        text =
+            if (isGuest) {
+                stringResource(Res.string.new_tree_guest_notice)
+            } else {
+                stringResource(Res.string.new_tree_footer)
+            },
         style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+        color =
+            if (isGuest) {
+                MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
+            } else {
+                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+            },
+        fontWeight = if (isGuest) FontWeight.Bold else FontWeight.Normal,
         textAlign = TextAlign.Center,
         modifier = Modifier.padding(horizontal = 48.dp),
     )
@@ -873,6 +885,7 @@ private class NewTreeStateProvider : PreviewParameterProvider<NewTreeState> {
                 sexualOrientationError = NewTreeState.ValidationError.EMPTY,
             ),
             NewTreeState(isLoading = true),
+            NewTreeState(isGuest = true),
         )
 }
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeState.kt
@@ -10,6 +10,7 @@ data class NewTreeState(
     val biologicalSexError: ValidationError? = null,
     val sexualOrientationError: ValidationError? = null,
     val isLoading: Boolean = false,
+    val isGuest: Boolean = false,
     val navigationEvent: String? = null,
     val showBirthDatePicker: Boolean = false,
     val showDeathDatePicker: Boolean = false,

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeViewModel.kt
@@ -3,6 +3,7 @@ package dev.saragones3.genogramia.presentation.newtree
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.saragones3.genogramia.domain.model.Person
+import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
 import dev.saragones3.genogramia.domain.usecase.NewTreeUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,10 +14,20 @@ import kotlinx.coroutines.launch
 
 class NewTreeViewModel(
     private val newTreeUseCase: NewTreeUseCase,
+    private val checkSessionUseCase: CheckSessionUseCase,
     private val dateFormatter: DateFormatter,
 ) : ViewModel() {
     private val _state = MutableStateFlow(NewTreeState())
     val state: StateFlow<NewTreeState> = _state.asStateFlow()
+
+    init {
+        checkUserStatus()
+    }
+
+    private fun checkUserStatus() {
+        val user = checkSessionUseCase()
+        _state.update { it.copy(isGuest = user == null) }
+    }
 
     fun onEvent(event: NewTreeEvent) {
         when (event) {
@@ -79,7 +90,9 @@ class NewTreeViewModel(
             }
 
             NewTreeEvent.OnResetState -> {
-                _state.value = NewTreeState()
+                _state.update { currentState ->
+                    NewTreeState(isGuest = currentState.isGuest)
+                }
             }
         }
     }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeViewModelTest.kt
@@ -2,9 +2,12 @@ package dev.saragones3.genogramia.presentation.newtree
 
 import app.cash.turbine.test
 import dev.saragones3.genogramia.domain.model.Person
+import dev.saragones3.genogramia.domain.model.User
+import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
 import dev.saragones3.genogramia.domain.usecase.NewTreeUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
 import dev.saragones3.genogramia.domain.util.DateProvider
+import dev.saragones3.genogramia.fakes.FakeAuthRepository
 import dev.saragones3.genogramia.fakes.FakeTreeRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,7 +24,8 @@ import kotlin.test.assertNull
 @OptIn(ExperimentalCoroutinesApi::class)
 class NewTreeViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
-    private val repository = FakeTreeRepository()
+    private val treeRepository = FakeTreeRepository()
+    private val authRepository = FakeAuthRepository()
 
     private val fakeDateProvider =
         object : DateProvider {
@@ -29,13 +33,15 @@ class NewTreeViewModelTest {
         }
 
     private val dateFormatter = DateFormatter()
-    private val createTreeUseCase = NewTreeUseCase(repository, fakeDateProvider, dateFormatter)
+    private val createTreeUseCase = NewTreeUseCase(treeRepository, fakeDateProvider, dateFormatter)
+    private val checkSessionUseCase = CheckSessionUseCase(authRepository)
     private lateinit var viewModel: NewTreeViewModel
 
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = NewTreeViewModel(createTreeUseCase, dateFormatter)
+        authRepository.setCurrentUser(null)
+        viewModel = NewTreeViewModel(createTreeUseCase, checkSessionUseCase, dateFormatter)
     }
 
     @AfterTest
@@ -57,6 +63,16 @@ class NewTreeViewModelTest {
             assertNull(state.lastNameError)
             assertEquals(false, state.showBirthDatePicker)
             assertEquals(false, state.showDeathDatePicker)
+            assertEquals(true, state.isGuest)
+        }
+
+    @Test
+    fun `when user is logged in isGuest is false`() =
+        runTest {
+            authRepository.setCurrentUser(User("uid", "email@test.com", "User"))
+            val viewModel = NewTreeViewModel(createTreeUseCase, checkSessionUseCase, dateFormatter)
+
+            assertEquals(false, viewModel.state.value.isGuest)
         }
 
     @Test
@@ -149,6 +165,7 @@ class NewTreeViewModelTest {
             viewModel.onEvent(NewTreeEvent.OnShowBirthDatePicker(true))
             assertEquals("John", viewModel.state.value.person.firstName)
             assertEquals(true, viewModel.state.value.showBirthDatePicker)
+            assertEquals(true, viewModel.state.value.isGuest)
 
             viewModel.onEvent(NewTreeEvent.OnResetState)
 
@@ -156,5 +173,6 @@ class NewTreeViewModelTest {
             assertEquals("", state.person.firstName)
             assertEquals(false, state.showBirthDatePicker)
             assertNull(state.firstNameError)
+            assertEquals(true, state.isGuest)
         }
 }


### PR DESCRIPTION
Implement the scenario where a guest user can create a temporary tree in memory. 

- Added 'Start Your First Tree' functionality for guest mode.
- Informed the user that changes are temporary and will be lost on close.
- Updated NewTreeViewModel to handle guest state.
- Added unit tests for the guest scenario.

Fixes #26