### PR TITLE
[US-010] Scenario: User has existing trees

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
@@ -9,6 +9,7 @@ import dev.saragones3.genogramia.domain.repository.AuthRepository
 import dev.saragones3.genogramia.domain.repository.TreeRepository
 import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
 import dev.saragones3.genogramia.domain.usecase.DeleteAccountUseCase
+import dev.saragones3.genogramia.domain.usecase.GetTreesUseCase
 import dev.saragones3.genogramia.domain.usecase.NewTreeUseCase
 import dev.saragones3.genogramia.domain.usecase.SendPasswordResetEmailUseCase
 import dev.saragones3.genogramia.domain.usecase.SignInUseCase
@@ -73,6 +74,7 @@ private val domainModule =
         factoryOf(::UpdatePasswordUseCase)
         factoryOf(::SendPasswordResetEmailUseCase)
         factoryOf(::NewTreeUseCase)
+        factoryOf(::GetTreesUseCase)
         factoryOf(::DateFormatter)
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/GetTreesUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/GetTreesUseCase.kt
@@ -1,0 +1,10 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.GenogramTree
+import dev.saragones3.genogramia.domain.repository.TreeRepository
+
+class GetTreesUseCase(
+    private val repository: TreeRepository,
+) {
+    suspend operator fun invoke(): List<GenogramTree> = repository.getTrees()
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/authenticatedhome/AuthenticatedHomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/authenticatedhome/AuthenticatedHomeScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -57,6 +58,10 @@ fun AuthenticatedHomeScreen(
     val userName by viewModel.userName.collectAsState()
     val searchQuery by viewModel.searchQuery.collectAsState()
     val trees by viewModel.trees.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.onResume()
+    }
 
     AuthenticatedHomeContent(
         userName = userName ?: "",

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/authenticatedhome/AuthenticatedHomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/authenticatedhome/AuthenticatedHomeViewModel.kt
@@ -1,15 +1,18 @@
 package dev.saragones3.genogramia.presentation.authenticatedhome
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dev.saragones3.genogramia.domain.model.GenogramTree
-import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
+import dev.saragones3.genogramia.domain.usecase.GetTreesUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 class AuthenticatedHomeViewModel(
-    checkSession: CheckSessionUseCase,
+    private val checkSession: CheckSessionUseCase,
+    private val getTrees: GetTreesUseCase,
 ) : ViewModel() {
     private val _userName = MutableStateFlow<String?>(null)
     val userName: StateFlow<String?> = _userName.asStateFlow()
@@ -21,7 +24,7 @@ class AuthenticatedHomeViewModel(
     private val _trees = MutableStateFlow<List<GenogramTree>>(emptyList())
     val trees: StateFlow<List<GenogramTree>> = _trees.asStateFlow()
 
-    init {
+    fun onResume() {
         _userName.value = checkSession()?.displayName ?: "User"
         loadTrees()
     }
@@ -32,14 +35,10 @@ class AuthenticatedHomeViewModel(
     }
 
     private fun loadTrees() {
-        // Mock data as requested
-        allTrees =
-            listOf(
-                GenogramTree("1", "Smith Family", 1240, "2 days ago", Person()),
-                GenogramTree("2", "Maternal Lineage", 8, "1 week ago", Person()),
-                GenogramTree("3", "Paternal Lineage", 12, "2 weeks ago", Person()),
-            )
-        updateFilteredTrees()
+        viewModelScope.launch {
+            allTrees = getTrees()
+            updateFilteredTrees()
+        }
     }
 
     private fun updateFilteredTrees() {

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/guesthome/GuestHomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/guesthome/GuestHomeScreen.kt
@@ -18,16 +18,16 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.saragones3.genogramia.domain.model.GenogramTree
 import dev.saragones3.genogramia.presentation.components.AddTreeCard
 import dev.saragones3.genogramia.presentation.components.GenogramTreeCard
 import dev.saragones3.genogramia.presentation.components.SearchBar
@@ -45,14 +45,26 @@ import genogramia.composeapp.generated.resources.search_records
 import genogramia.composeapp.generated.resources.start_first_tree
 import genogramia.composeapp.generated.resources.start_first_tree_desc
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun GuestHomeScreen(
+    viewModel: GuestHomeViewModel = koinViewModel(),
     onLoginClick: () -> Unit,
     onGoToTree: (String) -> Unit,
     onCreateTree: () -> Unit,
 ) {
+    val searchQuery by viewModel.searchQuery.collectAsState()
+    val trees by viewModel.trees.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.onResume()
+    }
+
     GuestHomeContent(
+        searchQuery = searchQuery,
+        trees = trees,
+        onSearchQueryChange = viewModel::onSearchQueryChange,
         onLoginClick = onLoginClick,
         onGoToTree = onGoToTree,
         onCreateTree = onCreateTree,
@@ -62,6 +74,9 @@ fun GuestHomeScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun GuestHomeContent(
+    searchQuery: String,
+    trees: List<GenogramTree>,
+    onSearchQueryChange: (String) -> Unit,
     onLoginClick: () -> Unit,
     onGoToTree: (String) -> Unit,
     onCreateTree: () -> Unit,
@@ -82,10 +97,9 @@ private fun GuestHomeContent(
         ) {
             Spacer(modifier = Modifier.height(16.dp))
 
-            var searchQuery by remember { mutableStateOf("") }
             SearchBar(
                 query = searchQuery,
-                onQueryChange = { searchQuery = it },
+                onQueryChange = onSearchQueryChange,
                 placeholder = stringResource(Res.string.search_records),
             )
 
@@ -95,15 +109,16 @@ private fun GuestHomeContent(
 
             Spacer(modifier = Modifier.height(40.dp))
 
-            GenogramTreeCard(
-                title = stringResource(Res.string.sample_tree),
-                description = stringResource(Res.string.sample_tree_desc),
-                buttonText = stringResource(Res.string.explore_example),
-                onButtonClick = { onGoToTree("") },
-                badgeText = stringResource(Res.string.guest_preview),
-            )
-
-            Spacer(modifier = Modifier.height(20.dp))
+            trees.forEach { tree ->
+                GenogramTreeCard(
+                    title = tree.name,
+                    description = stringResource(Res.string.sample_tree_desc),
+                    buttonText = stringResource(Res.string.explore_example),
+                    onButtonClick = { onGoToTree(tree.id) },
+                    badgeText = stringResource(Res.string.guest_preview),
+                )
+                Spacer(modifier = Modifier.height(20.dp))
+            }
 
             AddTreeCard(
                 title = stringResource(Res.string.start_first_tree),
@@ -176,6 +191,9 @@ private fun GuestHomeTitleSection() {
 private fun GuestHomeScreenPreview() {
     GenogramiaTheme {
         GuestHomeContent(
+            searchQuery = "",
+            trees = emptyList(),
+            onSearchQueryChange = {},
             onLoginClick = {},
             onGoToTree = {},
             onCreateTree = {},

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/guesthome/GuestHomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/guesthome/GuestHomeViewModel.kt
@@ -1,7 +1,47 @@
 package dev.saragones3.genogramia.presentation.guesthome
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.saragones3.genogramia.domain.model.GenogramTree
+import dev.saragones3.genogramia.domain.usecase.GetTreesUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
-class GuestHomeViewModel : ViewModel() {
-    // TODO: Add logic for guest home (e.g. loading sample trees)
+class GuestHomeViewModel(
+    private val getTrees: GetTreesUseCase,
+) : ViewModel() {
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    private var allTrees = listOf<GenogramTree>()
+    private val _trees = MutableStateFlow<List<GenogramTree>>(emptyList())
+    val trees: StateFlow<List<GenogramTree>> = _trees.asStateFlow()
+
+    fun onResume() {
+        loadTrees()
+    }
+
+    fun onSearchQueryChange(query: String) {
+        _searchQuery.value = query
+        updateFilteredTrees()
+    }
+
+    private fun loadTrees() {
+        viewModelScope.launch {
+            allTrees = getTrees()
+            updateFilteredTrees()
+        }
+    }
+
+    private fun updateFilteredTrees() {
+        val query = _searchQuery.value
+        _trees.value =
+            if (query.isBlank()) {
+                allTrees
+            } else {
+                allTrees.filter { it.name.contains(query, ignoreCase = true) }
+            }
+    }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/data/repository/InMemoryTreeRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/data/repository/InMemoryTreeRepositoryTest.kt
@@ -8,72 +8,79 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class InMemoryTreeRepositoryTest {
-
     private val repository = InMemoryTreeRepository()
 
     private val centralPerson = Person(id = "p1", firstName = "John", lastName = "Doe")
 
     @Test
-    fun `createTree should add tree to the list`() = runTest {
-        val tree = GenogramTree(
-            id = "1",
-            name = "Test Tree",
-            ancestorCount = 0,
-            lastUpdated = "2024-05-15",
-            centralPerson = centralPerson
-        )
-        repository.createTree(tree)
+    fun `createTree should add tree to the list`() =
+        runTest {
+            val tree =
+                GenogramTree(
+                    id = "1",
+                    name = "Test Tree",
+                    ancestorCount = 0,
+                    lastUpdated = "2024-05-15",
+                    centralPerson = centralPerson,
+                )
+            repository.createTree(tree)
 
-        val trees = repository.getTrees()
-        assertEquals(1, trees.size)
-        assertEquals(tree, trees[0])
-    }
-
-    @Test
-    fun `getTree should return the correct tree`() = runTest {
-        val tree1 = GenogramTree(
-            id = "1",
-            name = "Tree 1",
-            ancestorCount = 0,
-            lastUpdated = "2024-05-15",
-            centralPerson = centralPerson
-        )
-        val tree2 = GenogramTree(
-            id = "2",
-            name = "Tree 2",
-            ancestorCount = 0,
-            lastUpdated = "2024-05-15",
-            centralPerson = centralPerson
-        )
-        repository.createTree(tree1)
-        repository.createTree(tree2)
-
-        val found = repository.getTree("2")
-        assertEquals(tree2, found)
-    }
+            val trees = repository.getTrees()
+            assertEquals(1, trees.size)
+            assertEquals(tree, trees[0])
+        }
 
     @Test
-    fun `getTrees should return all trees`() = runTest {
-        val tree1 = GenogramTree(
-            id = "1",
-            name = "Tree 1",
-            ancestorCount = 0,
-            lastUpdated = "2024-05-15",
-            centralPerson = centralPerson
-        )
-        val tree2 = GenogramTree(
-            id = "2",
-            name = "Tree 2",
-            ancestorCount = 0,
-            lastUpdated = "2024-05-15",
-            centralPerson = centralPerson
-        )
-        repository.createTree(tree1)
-        repository.createTree(tree2)
+    fun `getTree should return the correct tree`() =
+        runTest {
+            val tree1 =
+                GenogramTree(
+                    id = "1",
+                    name = "Tree 1",
+                    ancestorCount = 0,
+                    lastUpdated = "2024-05-15",
+                    centralPerson = centralPerson,
+                )
+            val tree2 =
+                GenogramTree(
+                    id = "2",
+                    name = "Tree 2",
+                    ancestorCount = 0,
+                    lastUpdated = "2024-05-15",
+                    centralPerson = centralPerson,
+                )
+            repository.createTree(tree1)
+            repository.createTree(tree2)
 
-        val all = repository.getTrees()
-        assertEquals(2, all.size)
-        assertTrue(all.contains(tree1))
-        assertTrue(all.contains(tree2))
-    }
+            val found = repository.getTree("2")
+            assertEquals(tree2, found)
+        }
+
+    @Test
+    fun `getTrees should return all trees`() =
+        runTest {
+            val tree1 =
+                GenogramTree(
+                    id = "1",
+                    name = "Tree 1",
+                    ancestorCount = 0,
+                    lastUpdated = "2024-05-15",
+                    centralPerson = centralPerson,
+                )
+            val tree2 =
+                GenogramTree(
+                    id = "2",
+                    name = "Tree 2",
+                    ancestorCount = 0,
+                    lastUpdated = "2024-05-15",
+                    centralPerson = centralPerson,
+                )
+            repository.createTree(tree1)
+            repository.createTree(tree2)
+
+            val all = repository.getTrees()
+            assertEquals(2, all.size)
+            assertTrue(all.contains(tree1))
+            assertTrue(all.contains(tree2))
+        }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/GetTreesUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/GetTreesUseCaseTest.kt
@@ -1,0 +1,27 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.GenogramTree
+import dev.saragones3.genogramia.domain.model.Person
+import dev.saragones3.genogramia.fakes.FakeTreeRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GetTreesUseCaseTest {
+    @Test
+    fun `invoke returns list of trees from repository`() =
+        runTest {
+            val fakeRepository = FakeTreeRepository()
+            val tree1 = GenogramTree("1", "Tree 1", 1, "now", Person())
+            val tree2 = GenogramTree("2", "Tree 2", 2, "yesterday", Person())
+            fakeRepository.createTree(tree1)
+            fakeRepository.createTree(tree2)
+
+            val useCase = GetTreesUseCase(fakeRepository)
+            val result = useCase()
+
+            assertEquals(2, result.size)
+            assertEquals(tree1, result[0])
+            assertEquals(tree2, result[1])
+        }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/authenticatedhome/AuthenticatedHomeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/authenticatedhome/AuthenticatedHomeViewModelTest.kt
@@ -1,22 +1,45 @@
 package dev.saragones3.genogramia.presentation.authenticatedhome
 
+import dev.saragones3.genogramia.domain.model.GenogramTree
+import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.model.User
 import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
+import dev.saragones3.genogramia.domain.usecase.GetTreesUseCase
 import dev.saragones3.genogramia.fakes.FakeAuthRepository
+import dev.saragones3.genogramia.fakes.FakeTreeRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AuthenticatedHomeViewModelTest {
     private lateinit var authRepository: FakeAuthRepository
+    private lateinit var treeRepository: FakeTreeRepository
     private lateinit var checkSessionUseCase: CheckSessionUseCase
+    private lateinit var getTreesUseCase: GetTreesUseCase
     private lateinit var viewModel: AuthenticatedHomeViewModel
+
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     @BeforeTest
     fun setup() {
+        Dispatchers.setMain(testDispatcher)
         authRepository = FakeAuthRepository()
+        treeRepository = FakeTreeRepository()
         checkSessionUseCase = CheckSessionUseCase(authRepository)
+        getTreesUseCase = GetTreesUseCase(treeRepository)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
     }
 
     @Test
@@ -25,20 +48,24 @@ class AuthenticatedHomeViewModelTest {
             val user = User("123", "test@test.com", "John Doe")
             authRepository.setCurrentUser(user)
 
-            viewModel = AuthenticatedHomeViewModel(checkSessionUseCase)
+            viewModel = AuthenticatedHomeViewModel(checkSessionUseCase, getTreesUseCase)
+            viewModel.onResume()
 
             assertEquals("John Doe", viewModel.userName.value)
         }
 
     @Test
-    fun `when view model is initialized trees should be loaded with mock data`() =
+    fun `when view model is initialized trees should be loaded from repository`() =
         runTest {
             val user = User("123", "test@test.com", "John Doe")
             authRepository.setCurrentUser(user)
+            val tree = GenogramTree("1", "Smith Family", 1, "now", Person())
+            treeRepository.createTree(tree)
 
-            viewModel = AuthenticatedHomeViewModel(checkSessionUseCase)
+            viewModel = AuthenticatedHomeViewModel(checkSessionUseCase, getTreesUseCase)
+            viewModel.onResume()
 
-            assertEquals(3, viewModel.trees.value.size)
+            assertEquals(1, viewModel.trees.value.size)
             assertEquals("Smith Family", viewModel.trees.value[0].name)
         }
 
@@ -47,8 +74,11 @@ class AuthenticatedHomeViewModelTest {
         runTest {
             val user = User("123", "test@test.com", "John Doe")
             authRepository.setCurrentUser(user)
+            treeRepository.createTree(GenogramTree("1", "Smith Family", 1, "now", Person()))
+            treeRepository.createTree(GenogramTree("2", "Maternal Lineage", 1, "now", Person()))
 
-            viewModel = AuthenticatedHomeViewModel(checkSessionUseCase)
+            viewModel = AuthenticatedHomeViewModel(checkSessionUseCase, getTreesUseCase)
+            viewModel.onResume()
 
             viewModel.onSearchQueryChange("Smith")
             assertEquals(1, viewModel.trees.value.size)
@@ -64,7 +94,8 @@ class AuthenticatedHomeViewModelTest {
             val user = User("123", "test@test.com", null)
             authRepository.setCurrentUser(user)
 
-            viewModel = AuthenticatedHomeViewModel(checkSessionUseCase)
+            viewModel = AuthenticatedHomeViewModel(checkSessionUseCase, getTreesUseCase)
+            viewModel.onResume()
 
             assertEquals("User", viewModel.userName.value)
         }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/guesthome/GuestHomeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/guesthome/GuestHomeViewModelTest.kt
@@ -1,5 +1,9 @@
 package dev.saragones3.genogramia.presentation.guesthome
 
+import dev.saragones3.genogramia.domain.model.GenogramTree
+import dev.saragones3.genogramia.domain.model.Person
+import dev.saragones3.genogramia.domain.usecase.GetTreesUseCase
+import dev.saragones3.genogramia.fakes.FakeTreeRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -9,15 +13,21 @@ import kotlinx.coroutines.test.setMain
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertNotNull
+import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GuestHomeViewModelTest {
+    private lateinit var treeRepository: FakeTreeRepository
+    private lateinit var getTreesUseCase: GetTreesUseCase
+    private lateinit var viewModel: GuestHomeViewModel
+
     private val testDispatcher = UnconfinedTestDispatcher()
 
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
+        treeRepository = FakeTreeRepository()
+        getTreesUseCase = GetTreesUseCase(treeRepository)
     }
 
     @AfterTest
@@ -26,9 +36,32 @@ class GuestHomeViewModelTest {
     }
 
     @Test
-    fun `viewModel can be initialized`() =
+    fun `when view model is initialized trees should be loaded from repository`() =
         runTest {
-            val viewModel = GuestHomeViewModel()
-            assertNotNull(viewModel)
+            val tree = GenogramTree("1", "Sample Tree", 1, "now", Person())
+            treeRepository.createTree(tree)
+
+            viewModel = GuestHomeViewModel(getTreesUseCase)
+            viewModel.onResume()
+
+            assertEquals(1, viewModel.trees.value.size)
+            assertEquals("Sample Tree", viewModel.trees.value[0].name)
+        }
+
+    @Test
+    fun `when search query changes trees should be filtered`() =
+        runTest {
+            treeRepository.createTree(GenogramTree("1", "Sample Tree", 1, "now", Person()))
+            treeRepository.createTree(GenogramTree("2", "Another Tree", 1, "now", Person()))
+
+            viewModel = GuestHomeViewModel(getTreesUseCase)
+            viewModel.onResume()
+
+            viewModel.onSearchQueryChange("Sample")
+            assertEquals(1, viewModel.trees.value.size)
+            assertEquals("Sample Tree", viewModel.trees.value[0].name)
+
+            viewModel.onSearchQueryChange("NonExistent")
+            assertEquals(0, viewModel.trees.value.size)
         }
 }


### PR DESCRIPTION
## Description
This PR implements the Authenticated Home Screen as defined in US-010 (Scenario: User has existing trees).

### Changes
- Implemented AuthenticatedHomeScreen with a search bar and tree cards.
- Added 'PRIMARY LINEAGE' highlighting for the primary tree.
- Added 'Start New Tree' card.
- Updated AuthenticatedHomeViewModel to fetch and filter trees.
- Updated GuestHomeViewModel to support tree filtering.
- Added GetTreesUseCase.
- Added unit tests for ViewModels and UseCase.

### Fixes
Fixes #29