### PR TITLE
[US-015] Scenario: User opens the edit form for a node

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -153,5 +153,6 @@
 
     <!-- Add Person -->
     <string name="add_person_title">Añadir Familiar</string>
+    <string name="edit_person_title">Editar Familiar</string>
     <string name="add_person_save">Guardar Registro de Miembro</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -153,5 +153,6 @@
 
     <!-- Add Person -->
     <string name="add_person_title">Add Family Member</string>
+    <string name="edit_person_title">Edit Family Member</string>
     <string name="add_person_save">Save Member Record</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
@@ -10,6 +10,7 @@ import dev.saragones3.genogramia.domain.repository.TreeRepository
 import dev.saragones3.genogramia.domain.usecase.AddPersonUseCase
 import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
 import dev.saragones3.genogramia.domain.usecase.DeleteAccountUseCase
+import dev.saragones3.genogramia.domain.usecase.GetPersonUseCase
 import dev.saragones3.genogramia.domain.usecase.GetTreeUseCase
 import dev.saragones3.genogramia.domain.usecase.GetTreesUseCase
 import dev.saragones3.genogramia.domain.usecase.NewTreeUseCase
@@ -18,6 +19,7 @@ import dev.saragones3.genogramia.domain.usecase.SignInUseCase
 import dev.saragones3.genogramia.domain.usecase.SignOutUseCase
 import dev.saragones3.genogramia.domain.usecase.SignUpUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdatePasswordUseCase
+import dev.saragones3.genogramia.domain.usecase.UpdatePersonUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
 import dev.saragones3.genogramia.domain.util.DateProvider
 import dev.saragones3.genogramia.presentation.addperson.AddPersonViewModel
@@ -81,6 +83,8 @@ private val domainModule =
         factoryOf(::SendPasswordResetEmailUseCase)
         factoryOf(::NewTreeUseCase)
         factoryOf(::AddPersonUseCase)
+        factoryOf(::UpdatePersonUseCase)
+        factoryOf(::GetPersonUseCase)
         factoryOf(::GetTreesUseCase)
         factoryOf(::GetTreeUseCase)
         factoryOf(::DateFormatter)

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/GetPersonUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/GetPersonUseCase.kt
@@ -1,0 +1,20 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.Person
+import dev.saragones3.genogramia.domain.repository.TreeRepository
+
+class GetPersonUseCase(
+    private val repository: TreeRepository,
+) {
+    suspend operator fun invoke(
+        treeId: String,
+        personId: String,
+    ): Person? {
+        val tree = repository.getTree(treeId) ?: return null
+        return if (tree.centralPerson.id == personId) {
+            tree.centralPerson
+        } else {
+            tree.persons.find { it.id == personId }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/UpdatePersonUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/UpdatePersonUseCase.kt
@@ -1,0 +1,31 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.Person
+import dev.saragones3.genogramia.domain.repository.TreeRepository
+
+class UpdatePersonUseCase(
+    private val repository: TreeRepository,
+) {
+    suspend operator fun invoke(
+        treeId: String,
+        person: Person,
+    ): Result<Unit> {
+        return try {
+            val tree =
+                repository.getTree(treeId)
+                    ?: return Result.failure(Exception("Tree not found"))
+
+            val updatedPersons =
+                tree.persons.map {
+                    if (it.id == person.id) person else it
+                }
+
+            val updatedCentralPerson = if (tree.centralPerson.id == person.id) person else tree.centralPerson
+
+            repository.updateTree(tree.copy(persons = updatedPersons, centralPerson = updatedCentralPerson))
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonEvent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonEvent.kt
@@ -41,5 +41,10 @@ sealed interface AddPersonEvent {
         val treeId: String,
     ) : AddPersonEvent
 
+    data class Initialize(
+        val treeId: String,
+        val personId: String?,
+    ) : AddPersonEvent
+
     data object OnResetState : AddPersonEvent
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonScreen.kt
@@ -46,17 +46,23 @@ import genogramia.composeapp.generated.resources.Res
 import genogramia.composeapp.generated.resources.add_person_save
 import genogramia.composeapp.generated.resources.add_person_title
 import genogramia.composeapp.generated.resources.date_format
+import genogramia.composeapp.generated.resources.edit_person_title
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun AddPersonScreen(
     treeId: String,
+    personId: String? = null,
     onBackClick: () -> Unit,
     onPersonAdded: () -> Unit,
 ) {
     val viewModel: AddPersonViewModel = koinViewModel()
     val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(treeId, personId) {
+        viewModel.onEvent(AddPersonEvent.Initialize(treeId, personId))
+    }
 
     LaunchedEffect(state.isSuccess) {
         if (state.isSuccess) {
@@ -81,13 +87,22 @@ private fun AddPersonContent(
     onBackClick: () -> Unit,
     onEvent: (AddPersonEvent) -> Unit,
 ) {
+    val isEditMode = state.personId != null
+
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surface,
         topBar = {
             TopAppBar(
                 title = {
                     Text(
-                        text = stringResource(Res.string.add_person_title),
+                        text =
+                            if (isEditMode) {
+                                stringResource(
+                                    Res.string.edit_person_title,
+                                )
+                            } else {
+                                stringResource(Res.string.add_person_title)
+                            },
                         style = MaterialTheme.typography.titleLarge,
                         fontWeight = FontWeight.Bold,
                     )

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonState.kt
@@ -13,6 +13,7 @@ data class AddPersonState(
     val sexualOrientationError: ValidationError? = null,
     val showBirthDatePicker: Boolean = false,
     val showDeathDatePicker: Boolean = false,
+    val personId: String? = null,
 ) {
     enum class ValidationError {
         EMPTY,

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.usecase.AddPersonUseCase
+import dev.saragones3.genogramia.domain.usecase.GetPersonUseCase
+import dev.saragones3.genogramia.domain.usecase.UpdatePersonUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -13,6 +15,8 @@ import kotlinx.coroutines.launch
 
 class AddPersonViewModel(
     private val addPersonUseCase: AddPersonUseCase,
+    private val updatePersonUseCase: UpdatePersonUseCase,
+    private val getPersonUseCase: GetPersonUseCase,
     private val dateFormatter: DateFormatter,
 ) : ViewModel() {
     private val _state = MutableStateFlow(AddPersonState())
@@ -80,8 +84,53 @@ class AddPersonViewModel(
                 savePerson(event.treeId)
             }
 
+            is AddPersonEvent.Initialize -> {
+                initialize(event.treeId, event.personId)
+            }
+
             AddPersonEvent.OnResetState -> {
                 _state.update { AddPersonState() }
+            }
+        }
+    }
+
+    private fun initialize(
+        treeId: String,
+        personId: String?,
+    ) {
+        if (personId == null) {
+            _state.update { AddPersonState() }
+            return
+        }
+
+        _state.update { it.copy(isLoading = true, personId = personId) }
+        viewModelScope.launch {
+            val person = getPersonUseCase(treeId, personId)
+            if (person != null) {
+                _state.update {
+                    it.copy(
+                        isLoading = false,
+                        person =
+                            it.person.copy(
+                                firstName = person.firstName,
+                                lastName = person.lastName,
+                                biologicalSex = person.biologicalSex,
+                                sexualOrientation = person.sexualOrientation,
+                                birthDateMillis = person.birthDate,
+                                birthDateText =
+                                    person.birthDate.let { date ->
+                                        dateFormatter.formatDate(date, "dd/MM/yyyy")
+                                    },
+                                deathDateMillis = person.deathDate ?: 0L,
+                                deathDateText =
+                                    person.deathDate?.let { date ->
+                                        dateFormatter.formatDate(date, "dd/MM/yyyy")
+                                    } ?: "",
+                            ),
+                    )
+                }
+            } else {
+                _state.update { it.copy(isLoading = false) }
             }
         }
     }
@@ -135,17 +184,24 @@ class AddPersonViewModel(
 
         val person =
             Person(
-                id = "",
+                id = _state.value.personId ?: "",
                 firstName = personUi.firstName,
                 lastName = personUi.lastName,
                 birthDate = personUi.birthDateMillis,
                 biologicalSex = personUi.biologicalSex,
                 sexualOrientation = personUi.sexualOrientation,
-                deathDate = personUi.deathDateMillis,
+                deathDate = if (personUi.deathDateMillis != 0L) personUi.deathDateMillis else null,
             )
 
         viewModelScope.launch {
-            addPersonUseCase(treeId, person)
+            val result =
+                if (_state.value.personId != null) {
+                    updatePersonUseCase(treeId, person)
+                } else {
+                    addPersonUseCase(treeId, person)
+                }
+
+            result
                 .onSuccess {
                     _state.update { it.copy(isLoading = false, isSuccess = true) }
                 }.onFailure {

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavGraph.kt
@@ -186,8 +186,8 @@ private fun NavGraphContent(
             TreeScreen(
                 treeId = key.treeId,
                 onBackClick = { backStack.pop() },
-                onAddPersonClick = { treeId ->
-                    backStack.push(NavRoute.AddPerson(treeId))
+                onAddPersonClick = { treeId, personId ->
+                    backStack.push(NavRoute.AddPerson(treeId, personId))
                 },
             )
         }
@@ -195,6 +195,7 @@ private fun NavGraphContent(
         is NavRoute.AddPerson -> {
             AddPersonScreen(
                 treeId = key.treeId,
+                personId = key.personId,
                 onBackClick = { backStack.pop() },
                 onPersonAdded = { backStack.pop() },
             )

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavRoute.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavRoute.kt
@@ -44,5 +44,6 @@ sealed interface NavRoute {
     @Serializable
     data class AddPerson(
         val treeId: String,
+        val personId: String? = null,
     ) : NavRoute
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeEvent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeEvent.kt
@@ -33,4 +33,10 @@ sealed interface TreeEvent {
     data object OnNavigationConsumed : TreeEvent
 
     data object OnErrorConsumed : TreeEvent
+
+    data class OnPersonSelected(
+        val personId: String,
+    ) : TreeEvent
+
+    data object OnDismissSelection : TreeEvent
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
@@ -1,16 +1,15 @@
 package dev.saragones3.genogramia.presentation.tree
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -19,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.FilterCenterFocus
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.CircularProgressIndicator
@@ -51,11 +51,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.font.FontWeight
@@ -65,7 +65,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Constraints
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.saragones3.genogramia.domain.model.Person
@@ -83,7 +82,7 @@ import org.koin.compose.viewmodel.koinViewModel
 fun TreeScreen(
     treeId: String,
     onBackClick: () -> Unit,
-    onAddPersonClick: (String) -> Unit,
+    onAddPersonClick: (String, String?) -> Unit,
 ) {
     val viewModel: TreeViewModel = koinViewModel()
     val state by viewModel.state.collectAsState()
@@ -119,7 +118,8 @@ fun TreeScreen(
         state = state,
         onEvent = viewModel::onEvent,
         onBackClick = onBackClick,
-        onAddPersonClick = { onAddPersonClick(treeId) },
+        onAddPersonClick = { onAddPersonClick(treeId, null) },
+        onEditPersonClick = { personId -> onAddPersonClick(treeId, personId) },
         snackbarHostState = snackbarHostState,
     )
 }
@@ -131,8 +131,11 @@ private fun TreeContent(
     onEvent: (TreeEvent) -> Unit,
     onBackClick: () -> Unit,
     onAddPersonClick: () -> Unit,
+    onEditPersonClick: (String) -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
+    val isPersonSelected = state.selectedPersonId != null
+
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surface,
         topBar = {
@@ -163,14 +166,20 @@ private fun TreeContent(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
             FloatingActionButton(
-                onClick = onAddPersonClick,
+                onClick = {
+                    if (isPersonSelected) {
+                        onEditPersonClick(state.selectedPersonId)
+                    } else {
+                        onAddPersonClick()
+                    }
+                },
                 containerColor = MaterialTheme.colorScheme.primary,
                 contentColor = Color.White,
                 shape = CircleShape,
                 modifier = Modifier.size(56.dp),
             ) {
                 Icon(
-                    imageVector = Icons.Default.Add,
+                    imageVector = if (isPersonSelected) Icons.Default.Edit else Icons.Default.Add,
                     contentDescription = null,
                 )
             }
@@ -203,9 +212,12 @@ private fun TreeContent(
                 tree = state.tree,
                 offset = state.offset,
                 scale = state.scale,
+                selectedPersonId = state.selectedPersonId,
                 onTransform = { pan, zoom ->
                     onEvent(TreeEvent.OnTransform(pan, zoom))
                 },
+                onPersonSelected = { onEvent(TreeEvent.OnPersonSelected(it)) },
+                onDismissSelection = { onEvent(TreeEvent.OnDismissSelection) },
             )
 
             CanvasControls(
@@ -226,12 +238,16 @@ private fun GenogramCanvas(
     tree: TreeUi,
     offset: Offset,
     scale: Float,
+    selectedPersonId: String?,
     onTransform: (Offset, Float) -> Unit,
+    onPersonSelected: (String) -> Unit,
+    onDismissSelection: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val textMeasurer = rememberTextMeasurer()
     val theme = MaterialTheme.colorScheme
     val typography = MaterialTheme.typography
+    val nodeSize = with(LocalDensity.current) { 64.dp.toPx() }
 
     Box(
         modifier =
@@ -239,6 +255,24 @@ private fun GenogramCanvas(
                 .fillMaxSize()
                 .clipToBounds()
                 .pointerInput(Unit) {
+                    detectTapGestures { tapOffset ->
+                        val tappedPerson =
+                            (listOf(tree.centralPerson) + tree.persons).find {
+                                val personTopLeft =
+                                    Offset(it.position.x - nodeSize / 2, it.position.y - nodeSize / 2)
+                                tapOffset.x >= (personTopLeft.x * scale + offset.x) &&
+                                    tapOffset.x <= ((personTopLeft.x + nodeSize) * scale + offset.x) &&
+                                    tapOffset.y >= (personTopLeft.y * scale + offset.y) &&
+                                    tapOffset.y <= ((personTopLeft.y + nodeSize) * scale + offset.y)
+                            }
+
+                        if (tappedPerson != null) {
+                            onPersonSelected(tappedPerson.id)
+                        } else {
+                            onDismissSelection()
+                        }
+                    }
+                }.pointerInput(Unit) {
                     detectTransformGestures { _, pan, zoom, _ ->
                         onTransform(pan, zoom)
                     }
@@ -289,9 +323,21 @@ private fun GenogramCanvas(
                 }
 
                 // Draw persons
-                drawPerson(tree.centralPerson, textMeasurer, theme, typography)
+                drawPerson(
+                    person = tree.centralPerson,
+                    textMeasurer = textMeasurer,
+                    theme = theme,
+                    typography = typography,
+                    isSelected = tree.centralPerson.id == selectedPersonId,
+                )
                 tree.persons.forEach { person ->
-                    drawPerson(person, textMeasurer, theme, typography)
+                    drawPerson(
+                        person = person,
+                        textMeasurer = textMeasurer,
+                        theme = theme,
+                        typography = typography,
+                        isSelected = person.id == selectedPersonId,
+                    )
                 }
             }
         }
@@ -303,10 +349,15 @@ private fun DrawScope.drawPerson(
     textMeasurer: TextMeasurer,
     theme: ColorScheme,
     typography: Typography,
+    isSelected: Boolean,
 ) {
     val nodeSize = 64.dp.toPx()
     val center = person.position
     val topLeft = Offset(center.x - nodeSize / 2, center.y - nodeSize / 2)
+
+    if (isSelected) {
+        drawPersonSelection(person, nodeSize, center, topLeft, theme.primary)
+    }
 
     val color =
         when (person.biologicalSex) {
@@ -315,7 +366,59 @@ private fun DrawScope.drawPerson(
             else -> theme.secondary
         }
 
-    // Draw Shape
+    drawPersonShape(person, color, nodeSize, center, topLeft)
+    drawPersonIdentityMarkers(person, nodeSize, center, topLeft)
+    drawPersonTextInfo(person, textMeasurer, typography, nodeSize, center, topLeft)
+}
+
+private fun DrawScope.drawPersonSelection(
+    person: PersonNodeUi,
+    nodeSize: Float,
+    center: Offset,
+    topLeft: Offset,
+    color: Color,
+) {
+    val selectionPadding = 4.dp.toPx()
+    val selectionSize = nodeSize + selectionPadding * 2
+    val selectionTopLeft = Offset(topLeft.x - selectionPadding, topLeft.y - selectionPadding)
+
+    when (person.biologicalSex) {
+        Person.BiologicalSex.MALE -> {
+            drawRect(
+                color = color,
+                topLeft = selectionTopLeft,
+                size = Size(selectionSize, selectionSize),
+                style = Stroke(width = 3.dp.toPx()),
+            )
+        }
+
+        Person.BiologicalSex.FEMALE -> {
+            drawCircle(
+                color = color,
+                center = center,
+                radius = selectionSize / 2,
+                style = Stroke(width = 3.dp.toPx()),
+            )
+        }
+
+        else -> {
+            drawRect(
+                color = color,
+                topLeft = selectionTopLeft,
+                size = Size(selectionSize, selectionSize),
+                style = Stroke(width = 3.dp.toPx()),
+            )
+        }
+    }
+}
+
+private fun DrawScope.drawPersonShape(
+    person: PersonNodeUi,
+    color: Color,
+    nodeSize: Float,
+    center: Offset,
+    topLeft: Offset,
+) {
     when (person.biologicalSex) {
         Person.BiologicalSex.MALE -> {
             drawRect(color = color, topLeft = topLeft, size = Size(nodeSize, nodeSize))
@@ -365,8 +468,14 @@ private fun DrawScope.drawPerson(
             )
         }
     }
+}
 
-    // LGBT Triangle
+private fun DrawScope.drawPersonIdentityMarkers(
+    person: PersonNodeUi,
+    nodeSize: Float,
+    center: Offset,
+    topLeft: Offset,
+) {
     if (person.sexualOrientation != Person.SexualOrientation.HETEROSEXUAL &&
         person.sexualOrientation != Person.SexualOrientation.UNKNOWN
     ) {
@@ -381,7 +490,6 @@ private fun DrawScope.drawPerson(
         drawPath(path = trianglePath, color = Color.Black, style = Stroke(width = 2f))
     }
 
-    // Death X
     if (person.isDeceased) {
         drawLine(
             color = Color.Black,
@@ -396,7 +504,16 @@ private fun DrawScope.drawPerson(
             strokeWidth = 2f,
         )
     }
+}
 
+private fun DrawScope.drawPersonTextInfo(
+    person: PersonNodeUi,
+    textMeasurer: TextMeasurer,
+    typography: Typography,
+    nodeSize: Float,
+    center: Offset,
+    topLeft: Offset,
+) {
     // Text: Name (below)
     val nameResult =
         textMeasurer.measure(
@@ -606,6 +723,7 @@ private fun TreeScreenPreview(
             onEvent = {},
             onBackClick = {},
             onAddPersonClick = {},
+            onEditPersonClick = {},
             snackbarHostState = remember { SnackbarHostState() },
         )
     }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeState.kt
@@ -9,6 +9,7 @@ data class TreeState(
     val isLoading: Boolean = false,
     val error: TreeError? = null,
     val shouldNavigateBack: Boolean = false,
+    val selectedPersonId: String? = null,
 )
 
 enum class TreeError {

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
@@ -63,6 +63,14 @@ class TreeViewModel(
             TreeEvent.OnErrorConsumed -> {
                 _state.update { it.copy(error = null) }
             }
+
+            is TreeEvent.OnPersonSelected -> {
+                _state.update { it.copy(selectedPersonId = event.personId) }
+            }
+
+            TreeEvent.OnDismissSelection -> {
+                _state.update { it.copy(selectedPersonId = null) }
+            }
         }
     }
 
@@ -115,7 +123,7 @@ class TreeViewModel(
     }
 
     private fun Person.toNodeUi(): PersonNodeUi {
-        val birthYear = birthDate?.let { dateFormatter.formatDate(it, "yyyy") } ?: ""
+        val birthYear = birthDate.let { dateFormatter.formatDate(it, "yyyy") }
         val deathYear = deathDate?.let { dateFormatter.formatDate(it, "yyyy") } ?: ""
 
         val age =

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/GetPersonUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/GetPersonUseCaseTest.kt
@@ -1,0 +1,64 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.GenogramTree
+import dev.saragones3.genogramia.domain.model.Person
+import dev.saragones3.genogramia.fakes.FakeTreeRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GetPersonUseCaseTest {
+    private lateinit var repository: FakeTreeRepository
+    private lateinit var useCase: GetPersonUseCase
+
+    private val centralPerson = Person(id = "p1", firstName = "John", lastName = "Doe", birthDate = 0L)
+    private val otherPerson = Person(id = "p2", firstName = "Jane", lastName = "Doe", birthDate = 0L)
+    private val tree =
+        GenogramTree(
+            id = "tree-1",
+            name = "John Doe Lineage",
+            ancestorCount = 2,
+            lastUpdated = "2024-05-15",
+            centralPerson = centralPerson,
+            persons = listOf(otherPerson),
+        )
+
+    @BeforeTest
+    fun setup() {
+        repository = FakeTreeRepository()
+        useCase = GetPersonUseCase(repository)
+    }
+
+    @Test
+    fun `when person exists in persons list is returned`() =
+        runTest {
+            repository.createTree(tree)
+            val result = useCase("tree-1", "p2")
+            assertEquals(otherPerson, result)
+        }
+
+    @Test
+    fun `when person is central person is returned`() =
+        runTest {
+            repository.createTree(tree)
+            val result = useCase("tree-1", "p1")
+            assertEquals(centralPerson, result)
+        }
+
+    @Test
+    fun `when person does not exist returns null`() =
+        runTest {
+            repository.createTree(tree)
+            val result = useCase("tree-1", "invalid-p")
+            assertNull(result)
+        }
+
+    @Test
+    fun `when tree does not exist returns null`() =
+        runTest {
+            val result = useCase("invalid-tree", "p1")
+            assertNull(result)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/UpdatePersonUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/UpdatePersonUseCaseTest.kt
@@ -1,0 +1,68 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.GenogramTree
+import dev.saragones3.genogramia.domain.model.Person
+import dev.saragones3.genogramia.fakes.FakeTreeRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class UpdatePersonUseCaseTest {
+    private lateinit var repository: FakeTreeRepository
+    private lateinit var useCase: UpdatePersonUseCase
+
+    private val centralPerson = Person(id = "p1", firstName = "John", lastName = "Doe", birthDate = 0L)
+    private val otherPerson = Person(id = "p2", firstName = "Jane", lastName = "Doe", birthDate = 0L)
+    private val tree =
+        GenogramTree(
+            id = "tree-1",
+            name = "John Doe Lineage",
+            ancestorCount = 2,
+            lastUpdated = "2024-05-15",
+            centralPerson = centralPerson,
+            persons = listOf(otherPerson),
+        )
+
+    @BeforeTest
+    fun setup() {
+        repository = FakeTreeRepository()
+        useCase = UpdatePersonUseCase(repository)
+    }
+
+    @Test
+    fun `when person exists in persons list is updated successfully`() =
+        runTest {
+            repository.createTree(tree)
+            val updatedPerson = otherPerson.copy(firstName = "Jane Updated")
+
+            val result = useCase("tree-1", updatedPerson)
+
+            assertTrue(result.isSuccess)
+            val updatedTree = repository.getTree("tree-1")
+            assertEquals("Jane Updated", updatedTree?.persons?.find { it.id == "p2" }?.firstName)
+        }
+
+    @Test
+    fun `when person is central person is updated successfully`() =
+        runTest {
+            repository.createTree(tree)
+            val updatedPerson = centralPerson.copy(firstName = "John Updated")
+
+            val result = useCase("tree-1", updatedPerson)
+
+            assertTrue(result.isSuccess)
+            val updatedTree = repository.getTree("tree-1")
+            assertEquals("John Updated", updatedTree?.centralPerson?.firstName)
+        }
+
+    @Test
+    fun `when tree does not exist fails`() =
+        runTest {
+            val result = useCase("invalid-tree", otherPerson)
+
+            assertTrue(result.isFailure)
+            assertEquals("Tree not found", result.exceptionOrNull()?.message)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModelTest.kt
@@ -4,6 +4,8 @@ import app.cash.turbine.test
 import dev.saragones3.genogramia.domain.model.GenogramTree
 import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.usecase.AddPersonUseCase
+import dev.saragones3.genogramia.domain.usecase.GetPersonUseCase
+import dev.saragones3.genogramia.domain.usecase.UpdatePersonUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
 import dev.saragones3.genogramia.domain.util.DateProvider
 import dev.saragones3.genogramia.fakes.FakeTreeRepository
@@ -31,6 +33,8 @@ class AddPersonViewModelTest {
 
     private val dateFormatter = DateFormatter()
     private val addPersonUseCase = AddPersonUseCase(treeRepository, fakeDateProvider)
+    private val updatePersonUseCase = UpdatePersonUseCase(treeRepository)
+    private val getPersonUseCase = GetPersonUseCase(treeRepository)
     private lateinit var viewModel: AddPersonViewModel
 
     private val tree =
@@ -39,13 +43,20 @@ class AddPersonViewModelTest {
             name = "Test Tree",
             ancestorCount = 1,
             lastUpdated = "2024-05-15",
-            centralPerson = Person(id = "p1", firstName = "John", lastName = "Doe", birthDate = 0L),
+            centralPerson = Person(
+                id = "p1",
+                firstName = "John",
+                lastName = "Doe",
+                birthDate = 1778716800000L,
+                biologicalSex = Person.BiologicalSex.MALE,
+                sexualOrientation = Person.SexualOrientation.HETEROSEXUAL
+            ),
         )
 
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = AddPersonViewModel(addPersonUseCase, dateFormatter)
+        viewModel = AddPersonViewModel(addPersonUseCase, updatePersonUseCase, getPersonUseCase, dateFormatter)
     }
 
     @AfterTest
@@ -127,5 +138,63 @@ class AddPersonViewModelTest {
                 assertEquals(false, errorState.isLoading)
                 assertEquals(false, errorState.isSuccess)
             }
+        }
+
+    @Test
+    fun `when initialize event is received with personId data is loaded`() =
+        runTest {
+            treeRepository.createTree(tree)
+
+            viewModel.state.test {
+                awaitItem() // Initial
+
+                viewModel.onEvent(AddPersonEvent.Initialize("tree-1", "p1"))
+
+                assertEquals(true, awaitItem().isLoading)
+
+                val loadedState = awaitItem()
+                assertEquals(false, loadedState.isLoading)
+                assertEquals("p1", loadedState.personId)
+                assertEquals("John", loadedState.person.firstName)
+            }
+        }
+
+    @Test
+    fun `when saving in edit mode UpdatePersonUseCase is used`() =
+        runTest {
+            treeRepository.createTree(tree)
+
+            // Initialize to enter edit mode
+            viewModel.onEvent(AddPersonEvent.Initialize("tree-1", "p1"))
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.onEvent(AddPersonEvent.OnFirstNameChanged("John Updated"))
+
+            viewModel.onEvent(AddPersonEvent.OnSaveClicked("tree-1"))
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val updatedTree = treeRepository.getTree("tree-1")
+            assertEquals("John Updated", updatedTree?.centralPerson?.firstName)
+            assertEquals(true, viewModel.state.value.isSuccess)
+        }
+
+    @Test
+    fun `when initializing with null after an edit state is reset`() =
+        runTest {
+            treeRepository.createTree(tree)
+
+            // 1. Edit
+            viewModel.onEvent(AddPersonEvent.Initialize("tree-1", "p1"))
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertEquals("John", viewModel.state.value.person.firstName)
+
+            // 2. New (null)
+            viewModel.onEvent(AddPersonEvent.Initialize("tree-1", null))
+            
+            // 3. Assert reset
+            val state = viewModel.state.value
+            assertEquals("", state.person.firstName)
+            assertNull(state.personId)
+            assertEquals(false, state.isSuccess)
         }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModelTest.kt
@@ -43,14 +43,15 @@ class AddPersonViewModelTest {
             name = "Test Tree",
             ancestorCount = 1,
             lastUpdated = "2024-05-15",
-            centralPerson = Person(
-                id = "p1",
-                firstName = "John",
-                lastName = "Doe",
-                birthDate = 1778716800000L,
-                biologicalSex = Person.BiologicalSex.MALE,
-                sexualOrientation = Person.SexualOrientation.HETEROSEXUAL
-            ),
+            centralPerson =
+                Person(
+                    id = "p1",
+                    firstName = "John",
+                    lastName = "Doe",
+                    birthDate = 1778716800000L,
+                    biologicalSex = Person.BiologicalSex.MALE,
+                    sexualOrientation = Person.SexualOrientation.HETEROSEXUAL,
+                ),
         )
 
     @BeforeTest
@@ -190,7 +191,7 @@ class AddPersonViewModelTest {
 
             // 2. New (null)
             viewModel.onEvent(AddPersonEvent.Initialize("tree-1", null))
-            
+
             // 3. Assert reset
             val state = viewModel.state.value
             assertEquals("", state.person.firstName)

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
@@ -175,4 +175,19 @@ class TreeViewModelTest {
                     .firstName,
             )
         }
+
+    @Test
+    fun `when OnPersonSelected event is received selectedPersonId is updated`() =
+        runTest {
+            viewModel.onEvent(TreeEvent.OnPersonSelected("p1"))
+            assertEquals("p1", viewModel.state.value.selectedPersonId)
+        }
+
+    @Test
+    fun `when OnDismissSelection event is received selectedPersonId is cleared`() =
+        runTest {
+            viewModel.onEvent(TreeEvent.OnPersonSelected("p1"))
+            viewModel.onEvent(TreeEvent.OnDismissSelection)
+            assertNull(viewModel.state.value.selectedPersonId)
+        }
 }


### PR DESCRIPTION
Fixes #46. This PR implements the scenario where a user opens the edit form for a node. It includes teal selection highlighting for selected nodes, dynamically changing the FAB icon to a pencil, pre-filling the Add Family Member form with existing data upon tapping the edit FAB, and complete test suites.