### PR TITLE
feat: implement multi-selection and relationship UI [US-019]

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -155,4 +155,5 @@
     <string name="add_person_title">Añadir Familiar</string>
     <string name="edit_person_title">Editar Familiar</string>
     <string name="add_person_save">Guardar Registro de Miembro</string>
+    <string name="add_relationship">Añadir relación</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -155,4 +155,5 @@
     <string name="add_person_title">Add Family Member</string>
     <string name="edit_person_title">Edit Family Member</string>
     <string name="add_person_save">Save Member Record</string>
+    <string name="add_relationship">Add relationship</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonScreen.kt
@@ -152,6 +152,7 @@ private fun AddPersonContent(
             if (state.showBirthDatePicker) {
                 val dateFormat = stringResource(Res.string.date_format)
                 DatePickerModal(
+                    initialDate = state.person.birthDateMillis,
                     onDateSelected = { onEvent(AddPersonEvent.OnBirthDateSelected(it, dateFormat)) },
                     onDismiss = { onEvent(AddPersonEvent.OnShowBirthDatePicker(false)) },
                 )
@@ -160,6 +161,7 @@ private fun AddPersonContent(
             if (state.showDeathDatePicker) {
                 val dateFormat = stringResource(Res.string.date_format)
                 DatePickerModal(
+                    initialDate = state.person.deathDateMillis,
                     onDateSelected = { onEvent(AddPersonEvent.OnDeathDateSelected(it, dateFormat)) },
                     onDismiss = { onEvent(AddPersonEvent.OnShowDeathDatePicker(false)) },
                 )

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonState.kt
@@ -23,7 +23,7 @@ data class AddPersonState(
 data class AddPersonUi(
     val firstName: String = "",
     val lastName: String = "",
-    val birthDateMillis: Long = 0L,
+    val birthDateMillis: Long? = null,
     val birthDateText: String = "",
     val biologicalSex: Person.BiologicalSex = Person.BiologicalSex.UNKNOWN,
     val sexualOrientation: Person.SexualOrientation = Person.SexualOrientation.UNKNOWN,

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModel.kt
@@ -118,10 +118,8 @@ class AddPersonViewModel(
                                 sexualOrientation = person.sexualOrientation,
                                 birthDateMillis = person.birthDate,
                                 birthDateText =
-                                    person.birthDate.let { date ->
-                                        dateFormatter.formatDate(date, "dd/MM/yyyy")
-                                    },
-                                deathDateMillis = person.deathDate ?: 0L,
+                                    dateFormatter.formatDate(person.birthDate, "dd/MM/yyyy"),
+                                deathDateMillis = person.deathDate,
                                 deathDateText =
                                     person.deathDate?.let { date ->
                                         dateFormatter.formatDate(date, "dd/MM/yyyy")
@@ -154,7 +152,7 @@ class AddPersonViewModel(
             lastNameError = AddPersonState.ValidationError.EMPTY
             isValid = false
         }
-        if (personUi.birthDateMillis == 0L) {
+        if (personUi.birthDateMillis == null) {
             birthDateError = AddPersonState.ValidationError.EMPTY
             isValid = false
         }
@@ -187,10 +185,10 @@ class AddPersonViewModel(
                 id = _state.value.personId ?: "",
                 firstName = personUi.firstName,
                 lastName = personUi.lastName,
-                birthDate = personUi.birthDateMillis,
+                birthDate = personUi.birthDateMillis ?: 0L,
                 biologicalSex = personUi.biologicalSex,
                 sexualOrientation = personUi.sexualOrientation,
-                deathDate = if (personUi.deathDateMillis != 0L) personUi.deathDateMillis else null,
+                deathDate = personUi.deathDateMillis,
             )
 
         viewModelScope.launch {

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/components/PersonFormComponents.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/components/PersonFormComponents.kt
@@ -499,10 +499,11 @@ fun OptionSelector(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DatePickerModal(
+    initialDate: Long? = null,
     onDateSelected: (Long) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val datePickerState = rememberDatePickerState()
+    val datePickerState = rememberDatePickerState(initialSelectedDateMillis = initialDate)
 
     DatePickerDialog(
         onDismissRequest = onDismiss,

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeScreen.kt
@@ -161,6 +161,7 @@ private fun NewTreeContent(
 
         if (state.showBirthDatePicker) {
             DatePickerModal(
+                initialDate = state.person.birthDateMillis,
                 onDateSelected = { onEvent(NewTreeEvent.OnBirthDateSelected(it, dateFormat)) },
                 onDismiss = { onEvent(NewTreeEvent.OnShowBirthDatePicker(false)) },
             )
@@ -168,6 +169,7 @@ private fun NewTreeContent(
 
         if (state.showDeathDatePicker) {
             DatePickerModal(
+                initialDate = state.person.deathDateMillis,
                 onDateSelected = { onEvent(NewTreeEvent.OnDeathDateSelected(it, dateFormat)) },
                 onDismiss = { onEvent(NewTreeEvent.OnShowDeathDatePicker(false)) },
             )

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeState.kt
@@ -23,7 +23,7 @@ data class NewTreeState(
 data class NewTreeUi(
     val firstName: String = "",
     val lastName: String = "",
-    val birthDateMillis: Long = 0L,
+    val birthDateMillis: Long? = null,
     val birthDateText: String = "",
     val biologicalSex: Person.BiologicalSex = Person.BiologicalSex.UNKNOWN,
     val sexualOrientation: Person.SexualOrientation = Person.SexualOrientation.UNKNOWN,

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeViewModel.kt
@@ -121,7 +121,7 @@ class NewTreeViewModel(
             lastNameError = NewTreeState.ValidationError.EMPTY
             isValid = false
         }
-        if (personUi.birthDateMillis == 0L) {
+        if (personUi.birthDateMillis == null) {
             birthDateError = NewTreeState.ValidationError.EMPTY
             isValid = false
         }
@@ -155,7 +155,7 @@ class NewTreeViewModel(
                     id = "",
                     firstName = personUi.firstName,
                     lastName = personUi.lastName,
-                    birthDate = personUi.birthDateMillis,
+                    birthDate = personUi.birthDateMillis ?: 0L,
                     biologicalSex = personUi.biologicalSex,
                     sexualOrientation = personUi.sexualOrientation,
                     deathDate = personUi.deathDateMillis,

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeEvent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeEvent.kt
@@ -26,6 +26,7 @@ sealed interface TreeEvent {
     ) : TreeEvent
 
     data class OnTransform(
+        val centroid: Offset,
         val pan: Offset,
         val zoom: Float,
     ) : TreeEvent
@@ -41,4 +42,9 @@ sealed interface TreeEvent {
     data object OnDismissSelection : TreeEvent
 
     data object OnAddRelationship : TreeEvent
+
+    data class OnPersonMove(
+        val personId: String,
+        val delta: Offset,
+    ) : TreeEvent
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeEvent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeEvent.kt
@@ -39,4 +39,6 @@ sealed interface TreeEvent {
     ) : TreeEvent
 
     data object OnDismissSelection : TreeEvent
+
+    data object OnAddRelationship : TreeEvent
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
@@ -393,28 +393,28 @@ private fun PersonNodeView(
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier
+        modifier =
+            modifier
                 .offset {
                     IntOffset(
                         (person.position.x.dp - 50.dp).roundToPx(),
                         (person.position.y.dp - 56.dp).roundToPx(),
                     )
-                }
-                .width(100.dp)
+                }.width(100.dp)
                 .combinedClickable(
                     onClick = onSelected,
                     indication = null,
-                    interactionSource = remember { MutableInteractionSource() }
-                )
-                .pointerInput(person.id) {
+                    interactionSource = remember { MutableInteractionSource() },
+                ).pointerInput(person.id) {
                     detectDragGestures { change, dragAmount ->
                         change.consume()
-                        val deltaDp = with(density) {
-                            Offset(
-                                x = dragAmount.x.toDp().value,
-                                y = dragAmount.y.toDp().value,
-                            )
-                        }
+                        val deltaDp =
+                            with(density) {
+                                Offset(
+                                    x = dragAmount.x.toDp().value,
+                                    y = dragAmount.y.toDp().value,
+                                )
+                            }
                         currentOnMove(deltaDp)
                     }
                 },
@@ -431,21 +431,23 @@ private fun PersonNodeView(
             shape = shape,
             backgroundColor = backgroundColor,
             size = with(density) { NODE_SIZE.toPx() },
-            modifier = Modifier
-                .nodeBorder(shape, isSelected, person.isIndexPerson)
-                .background(backgroundColor, shape)
-                .size(NODE_SIZE)
-                .padding(4.dp)
+            modifier =
+                Modifier
+                    .nodeBorder(shape, isSelected, person.isIndexPerson)
+                    .background(backgroundColor, shape)
+                    .size(NODE_SIZE)
+                    .padding(4.dp),
         )
 
         Spacer(modifier = Modifier.height(4.dp))
 
         Text(
             text = "${person.firstName} ${person.lastName}",
-            style = MaterialTheme.typography.bodyMedium.copy(
-                fontWeight = FontWeight.SemiBold,
-                textAlign = TextAlign.Center,
-            ),
+            style =
+                MaterialTheme.typography.bodyMedium.copy(
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Center,
+                ),
             textAlign = TextAlign.Center,
             maxLines = 2,
         )
@@ -456,12 +458,12 @@ private fun PersonNodeView(
 private fun PersonDates(
     birthDate: String,
     deathDate: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
+        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         if (birthDate.isNotEmpty()) {
             Text(
@@ -495,18 +497,20 @@ private fun PersonShape(
     ) {
         if (person.isDeceased) {
             Canvas(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(if (shape == CircleShape) 6.dp else 0.dp)
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(if (shape == CircleShape) 6.dp else 0.dp),
             ) {
                 drawDeathMark()
             }
         }
         if (person.sexualOrientation == Person.SexualOrientation.OTHER) {
             Canvas(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(if (shape == CircleShape) 6.dp else 0.dp)
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(if (shape == CircleShape) 6.dp else 0.dp),
             ) {
                 drawSexualOrientationMark(nodeSize = size)
             }
@@ -515,13 +519,14 @@ private fun PersonShape(
         if (person.age.isNotEmpty()) {
             Text(
                 text = person.age,
-                style = MaterialTheme.typography.bodySmall.copy(
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.Bold,
-                    textAlign = TextAlign.Center,
-                ),
+                style =
+                    MaterialTheme.typography.bodySmall.copy(
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Center,
+                    ),
                 textAlign = TextAlign.Center,
-                modifier = Modifier.background(backgroundColor)
+                modifier = Modifier.background(backgroundColor),
             )
         }
     }
@@ -532,24 +537,25 @@ private fun DrawScope.drawDeathMark() {
         color = Color.Black,
         start = Offset.Zero,
         end = Offset(size.width, size.height),
-        strokeWidth = 4f
+        strokeWidth = 4f,
     )
     drawLine(
         color = Color.Black,
         start = Offset(size.width, 0f),
         end = Offset(0f, size.height),
-        strokeWidth = 4f
+        strokeWidth = 4f,
     )
 }
 
 private fun DrawScope.drawSexualOrientationMark(nodeSize: Float) {
-    val trianglePath = Path().apply {
-        val triangleSize = nodeSize * 0.7f
-        moveTo(center.x - triangleSize / 2, center.y - triangleSize / 3)
-        lineTo(center.x + triangleSize / 2, center.y - triangleSize / 3)
-        lineTo(center.x, center.y + triangleSize * 2 / 3)
-        close()
-    }
+    val trianglePath =
+        Path().apply {
+            val triangleSize = nodeSize * 0.7f
+            moveTo(center.x - triangleSize / 2, center.y - triangleSize / 3)
+            lineTo(center.x + triangleSize / 2, center.y - triangleSize / 3)
+            lineTo(center.x, center.y + triangleSize * 2 / 3)
+            close()
+        }
     drawPath(
         path = trianglePath,
         color = Color.Black,
@@ -577,12 +583,10 @@ private fun RelationshipTooltip(
                         layout(placeable.width, placeable.height) {
                             placeable.placeRelative(-placeable.width / 2, -placeable.height / 2)
                         }
-                    }
-                    .pointerInput(Unit) {
+                    }.pointerInput(Unit) {
                         // Prevent taps on tooltip from being handled by the canvas
                         detectTapGestures { }
-                    }
-                    .height(32.dp),
+                    }.height(32.dp),
             shape = RoundedCornerShape(16.dp),
             color = Color.White,
             shadowElevation = 4.dp,
@@ -670,22 +674,25 @@ private fun Modifier.nodeBorder(
                 color = MaterialTheme.colorScheme.primary,
                 shape = shape,
             )
-        } else Modifier
-    )
-    .padding(4.dp)
+        } else {
+            Modifier
+        },
+    ).padding(4.dp)
     .then(
         if (isIndex) {
             Modifier.border(shape).padding(4.dp)
-        } else Modifier
-    )
-    .border(shape)
+        } else {
+            Modifier
+        },
+    ).border(shape)
 
 @Composable
-private fun Modifier.border(shape: Shape) = border(
-    width = 1.dp,
-    color = Color.Black,
-    shape = shape,
-)
+private fun Modifier.border(shape: Shape) =
+    border(
+        width = 1.dp,
+        color = Color.Black,
+        shape = shape,
+    )
 
 private val NODE_SIZE = 64.dp
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextMeasurer
@@ -70,6 +71,7 @@ import androidx.compose.ui.unit.sp
 import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.ui.theme.GenogramiaTheme
 import genogramia.composeapp.generated.resources.Res
+import genogramia.composeapp.generated.resources.add_relationship
 import genogramia.composeapp.generated.resources.canvas_reset
 import genogramia.composeapp.generated.resources.canvas_zoom_in
 import genogramia.composeapp.generated.resources.canvas_zoom_out
@@ -134,8 +136,6 @@ private fun TreeContent(
     onEditPersonClick: (String) -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
-    val isPersonSelected = state.selectedPersonId != null
-
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surface,
         topBar = {
@@ -165,23 +165,25 @@ private fun TreeContent(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
-            FloatingActionButton(
-                onClick = {
-                    if (isPersonSelected) {
-                        onEditPersonClick(state.selectedPersonId)
-                    } else {
-                        onAddPersonClick()
-                    }
-                },
-                containerColor = MaterialTheme.colorScheme.primary,
-                contentColor = Color.White,
-                shape = CircleShape,
-                modifier = Modifier.size(56.dp),
-            ) {
-                Icon(
-                    imageVector = if (isPersonSelected) Icons.Default.Edit else Icons.Default.Add,
-                    contentDescription = null,
-                )
+            if (state.selectedPersonIds.size < 2) {
+                FloatingActionButton(
+                    onClick = {
+                        if (state.selectedPersonIds.size == 1) {
+                            onEditPersonClick(state.selectedPersonIds.first())
+                        } else {
+                            onAddPersonClick()
+                        }
+                    },
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = Color.White,
+                    shape = CircleShape,
+                    modifier = Modifier.size(56.dp),
+                ) {
+                    Icon(
+                        imageVector = if (state.selectedPersonIds.size == 1) Icons.Default.Edit else Icons.Default.Add,
+                        contentDescription = null,
+                    )
+                }
             }
         },
     ) { padding ->
@@ -212,12 +214,15 @@ private fun TreeContent(
                 tree = state.tree,
                 offset = state.offset,
                 scale = state.scale,
-                selectedPersonId = state.selectedPersonId,
+                selectedPersonIds = state.selectedPersonIds,
                 onTransform = { pan, zoom ->
                     onEvent(TreeEvent.OnTransform(pan, zoom))
                 },
                 onPersonSelected = { onEvent(TreeEvent.OnPersonSelected(it)) },
                 onDismissSelection = { onEvent(TreeEvent.OnDismissSelection) },
+                onAddRelationshipClick = {
+                    onEvent(TreeEvent.OnAddRelationship)
+                },
             )
 
             CanvasControls(
@@ -238,10 +243,11 @@ private fun GenogramCanvas(
     tree: TreeUi,
     offset: Offset,
     scale: Float,
-    selectedPersonId: String?,
+    selectedPersonIds: List<String>,
     onTransform: (Offset, Float) -> Unit,
     onPersonSelected: (String) -> Unit,
     onDismissSelection: () -> Unit,
+    onAddRelationshipClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val textMeasurer = rememberTextMeasurer()
@@ -328,7 +334,7 @@ private fun GenogramCanvas(
                     textMeasurer = textMeasurer,
                     theme = theme,
                     typography = typography,
-                    isSelected = tree.centralPerson.id == selectedPersonId,
+                    isSelected = selectedPersonIds.contains(tree.centralPerson.id),
                 )
                 tree.persons.forEach { person ->
                     drawPerson(
@@ -336,9 +342,56 @@ private fun GenogramCanvas(
                         textMeasurer = textMeasurer,
                         theme = theme,
                         typography = typography,
-                        isSelected = person.id == selectedPersonId,
+                        isSelected = selectedPersonIds.contains(person.id),
                     )
                 }
+
+                // Draw dashed line between selected persons
+                if (selectedPersonIds.size == 2) {
+                    val p1 = (listOf(tree.centralPerson) + tree.persons).find { it.id == selectedPersonIds.first() }
+                    val p2 = (listOf(tree.centralPerson) + tree.persons).find { it.id == selectedPersonIds.last() }
+                    if (p1 != null && p2 != null) {
+                        drawLine(
+                            color = Color(0xFF008080),
+                            start = p1.position,
+                            end = p2.position,
+                            strokeWidth = 2.dp.toPx(),
+                            pathEffect =
+                                androidx.compose.ui.graphics.PathEffect.dashPathEffect(
+                                    floatArrayOf(10f, 10f),
+                                    0f,
+                                ),
+                        )
+                    }
+                }
+            }
+        }
+
+        // Tooltip between nodes if 2 are selected
+        if (selectedPersonIds.size == 2) {
+            val p1 =
+                (listOf(tree.centralPerson) + tree.persons).find { it.id == selectedPersonIds.first() }
+            val p2 =
+                (listOf(tree.centralPerson) + tree.persons).find { it.id == selectedPersonIds.last() }
+
+            if (p1 != null && p2 != null) {
+                val center1 = p1.position * scale + offset
+                val center2 = p2.position * scale + offset
+                val tooltipCenter = (center1 + center2) / 2f
+
+                RelationshipTooltip(
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopStart)
+                            .graphicsLayer {
+                                translationX = tooltipCenter.x
+                                translationY = tooltipCenter.y
+                            }.pointerInput(Unit) {
+                                // Prevent taps on tooltip from being handled by the canvas
+                                detectTapGestures { }
+                            },
+                    onClick = onAddRelationshipClick,
+                )
             }
         }
     }
@@ -588,6 +641,41 @@ private fun DrawScope.drawPersonTextInfo(
                     center.y - ageResult.size.height / 2,
                 ),
         )
+    }
+}
+
+@Composable
+private fun RelationshipTooltip(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val density = LocalDensity.current
+    val halfWidthPx = with(density) { 60.dp.toPx() }
+    val halfHeightPx = with(density) { 16.dp.toPx() }
+
+    Surface(
+        onClick = onClick,
+        modifier =
+            modifier
+                .height(32.dp)
+                .graphicsLayer {
+                    translationX -= halfWidthPx
+                    translationY -= halfHeightPx
+                },
+        shape = RoundedCornerShape(16.dp),
+        color = Color.White,
+        shadowElevation = 4.dp,
+    ) {
+        Box(
+            modifier = Modifier.padding(horizontal = 12.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = stringResource(Res.string.add_relationship),
+                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
+                color = Color.Black,
+            )
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
@@ -1,15 +1,24 @@
 package dev.saragones3.genogramia.presentation.tree
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -22,7 +31,6 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.FilterCenterFocus
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -35,37 +43,38 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.Typography
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.TextMeasurer
-import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.saragones3.genogramia.domain.model.Person
@@ -194,13 +203,24 @@ private fun TreeContent(
                     .padding(padding),
         ) {
             val center = Offset(constraints.maxWidth / 2f, constraints.maxHeight / 2f)
+            val density = LocalDensity.current
+
+            val resetViewport = {
+                val centralPerson = state.tree.centralPerson
+                val personPosPx =
+                    Offset(
+                        centralPerson.position.x * density.density,
+                        centralPerson.position.y * density.density,
+                    )
+                onEvent(TreeEvent.OnResetToCenter(center - personPosPx))
+            }
 
             // Initial centering when tree is loaded
-            var initialized by remember { mutableStateOf(false) }
-            LaunchedEffect(state.tree) {
-                if (!initialized) {
-                    onEvent(TreeEvent.OnResetToCenter(center))
-                    initialized = true
+            var lastLoadedTreeId by remember { mutableStateOf("") }
+            LaunchedEffect(state.tree.id) {
+                if (state.tree.id.isNotEmpty() && state.tree.id != lastLoadedTreeId) {
+                    resetViewport()
+                    lastLoadedTreeId = state.tree.id
                 }
             }
 
@@ -211,18 +231,8 @@ private fun TreeContent(
             }
 
             GenogramCanvas(
-                tree = state.tree,
-                offset = state.offset,
-                scale = state.scale,
-                selectedPersonIds = state.selectedPersonIds,
-                onTransform = { pan, zoom ->
-                    onEvent(TreeEvent.OnTransform(pan, zoom))
-                },
-                onPersonSelected = { onEvent(TreeEvent.OnPersonSelected(it)) },
-                onDismissSelection = { onEvent(TreeEvent.OnDismissSelection) },
-                onAddRelationshipClick = {
-                    onEvent(TreeEvent.OnAddRelationship)
-                },
+                state = state,
+                onEvent = onEvent,
             )
 
             CanvasControls(
@@ -232,7 +242,7 @@ private fun TreeContent(
                         .padding(bottom = 24.dp),
                 onZoomIn = { onEvent(TreeEvent.OnZoomIn()) },
                 onZoomOut = { onEvent(TreeEvent.OnZoomOut()) },
-                onReset = { onEvent(TreeEvent.OnResetToCenter(center)) },
+                onReset = resetViewport,
             )
         }
     }
@@ -240,21 +250,17 @@ private fun TreeContent(
 
 @Composable
 private fun GenogramCanvas(
-    tree: TreeUi,
-    offset: Offset,
-    scale: Float,
-    selectedPersonIds: List<String>,
-    onTransform: (Offset, Float) -> Unit,
-    onPersonSelected: (String) -> Unit,
-    onDismissSelection: () -> Unit,
-    onAddRelationshipClick: () -> Unit,
+    state: TreeState,
+    onEvent: (TreeEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val textMeasurer = rememberTextMeasurer()
-    val theme = MaterialTheme.colorScheme
-    val typography = MaterialTheme.typography
-    val nodeSize = with(LocalDensity.current) { 64.dp.toPx() }
+    val persons = remember(state.tree) { listOf(state.tree.centralPerson) + state.tree.persons }
+    val offset = state.offset
+    val scale = state.scale
+    val selectedPersonIds = state.selectedPersonIds
 
+    val density = LocalDensity.current
+    val nodeSize = with(density) { NODE_SIZE.toPx() }
     Box(
         modifier =
             modifier
@@ -263,9 +269,11 @@ private fun GenogramCanvas(
                 .pointerInput(Unit) {
                     detectTapGestures { tapOffset ->
                         val tappedPerson =
-                            (listOf(tree.centralPerson) + tree.persons).find {
+                            persons.find {
+                                val centerX = it.position.x * density.density
+                                val centerY = it.position.y * density.density
                                 val personTopLeft =
-                                    Offset(it.position.x - nodeSize / 2, it.position.y - nodeSize / 2)
+                                    Offset(centerX - nodeSize / 2, centerY - nodeSize / 2)
                                 tapOffset.x >= (personTopLeft.x * scale + offset.x) &&
                                     tapOffset.x <= ((personTopLeft.x + nodeSize) * scale + offset.x) &&
                                     tapOffset.y >= (personTopLeft.y * scale + offset.y) &&
@@ -273,91 +281,44 @@ private fun GenogramCanvas(
                             }
 
                         if (tappedPerson != null) {
-                            onPersonSelected(tappedPerson.id)
+                            onEvent(TreeEvent.OnPersonSelected(tappedPerson.id))
                         } else {
-                            onDismissSelection()
+                            onEvent(TreeEvent.OnDismissSelection)
                         }
                     }
                 }.pointerInput(Unit) {
-                    detectTransformGestures { _, pan, zoom, _ ->
-                        onTransform(pan, zoom)
+                    detectTransformGestures { centroid, pan, zoom, _ ->
+                        onEvent(TreeEvent.OnTransform(centroid, pan, zoom))
                     }
                 },
     ) {
-        Canvas(modifier = Modifier.fillMaxSize()) {
-            withTransform(
-                {
-                    translate(offset.x, offset.y)
-                    scale(scale, scale)
-                },
-            ) {
-                // Draw Infinite Grid
-                val gridStep = 40.dp.toPx()
-                val color = Color.LightGray.copy(alpha = 0.3f)
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        translationX = offset.x
+                        translationY = offset.y
+                        scaleX = scale
+                        scaleY = scale
+                        transformOrigin = TransformOrigin(0f, 0f)
+                    },
+        ) {
+            GridBackground()
 
-                val visibleWidth = size.width / scale
-                val visibleHeight = size.height / scale
-
-                val startX = -offset.x / scale
-                val startY = -offset.y / scale
-
-                val left = ((startX / gridStep).toInt() * gridStep) - gridStep
-                val top = ((startY / gridStep).toInt() * gridStep) - gridStep
-                val right = left + visibleWidth + (gridStep * 2)
-                val bottom = top + visibleHeight + (gridStep * 2)
-
-                var x = left
-                while (x < right) {
-                    drawLine(
-                        color = color,
-                        start = Offset(x, top),
-                        end = Offset(x, bottom),
-                        strokeWidth = 1f,
-                    )
-                    x += gridStep
-                }
-
-                var y = top
-                while (y < bottom) {
-                    drawLine(
-                        color = color,
-                        start = Offset(left, y),
-                        end = Offset(right, y),
-                        strokeWidth = 1f,
-                    )
-                    y += gridStep
-                }
-
-                // Draw persons
-                drawPerson(
-                    person = tree.centralPerson,
-                    textMeasurer = textMeasurer,
-                    theme = theme,
-                    typography = typography,
-                    isSelected = selectedPersonIds.contains(tree.centralPerson.id),
-                )
-                tree.persons.forEach { person ->
-                    drawPerson(
-                        person = person,
-                        textMeasurer = textMeasurer,
-                        theme = theme,
-                        typography = typography,
-                        isSelected = selectedPersonIds.contains(person.id),
-                    )
-                }
-
-                // Draw dashed line between selected persons
+            // Selection line
+            Canvas(modifier = Modifier.fillMaxSize()) {
                 if (selectedPersonIds.size == 2) {
-                    val p1 = (listOf(tree.centralPerson) + tree.persons).find { it.id == selectedPersonIds.first() }
-                    val p2 = (listOf(tree.centralPerson) + tree.persons).find { it.id == selectedPersonIds.last() }
+                    val p1 = persons.find { it.id == selectedPersonIds.first() }
+                    val p2 = persons.find { it.id == selectedPersonIds.last() }
                     if (p1 != null && p2 != null) {
                         drawLine(
                             color = Color(0xFF008080),
-                            start = p1.position,
-                            end = p2.position,
+                            start = p1.position * density.density,
+                            end = p2.position * density.density,
                             strokeWidth = 2.dp.toPx(),
                             pathEffect =
-                                androidx.compose.ui.graphics.PathEffect.dashPathEffect(
+                                PathEffect.dashPathEffect(
                                     floatArrayOf(10f, 10f),
                                     0f,
                                 ),
@@ -365,316 +326,278 @@ private fun GenogramCanvas(
                     }
                 }
             }
-        }
+            persons.forEach { person ->
+                key(person.id) {
+                    PersonNodeView(
+                        person = person,
+                        isSelected = selectedPersonIds.contains(person.id),
+                        onSelected = { onEvent(TreeEvent.OnPersonSelected(person.id)) },
+                        onMove = { delta -> onEvent(TreeEvent.OnPersonMove(person.id, delta)) },
+                    )
+                }
+            }
 
-        // Tooltip between nodes if 2 are selected
-        if (selectedPersonIds.size == 2) {
-            val p1 =
-                (listOf(tree.centralPerson) + tree.persons).find { it.id == selectedPersonIds.first() }
-            val p2 =
-                (listOf(tree.centralPerson) + tree.persons).find { it.id == selectedPersonIds.last() }
-
-            if (p1 != null && p2 != null) {
-                val center1 = p1.position * scale + offset
-                val center2 = p2.position * scale + offset
-                val tooltipCenter = (center1 + center2) / 2f
-
+            if (selectedPersonIds.size == 2) {
+                val p1 = persons.find { it.id == selectedPersonIds.first() }
+                val p2 = persons.find { it.id == selectedPersonIds.last() }
                 RelationshipTooltip(
-                    modifier =
-                        Modifier
-                            .align(Alignment.TopStart)
-                            .graphicsLayer {
-                                translationX = tooltipCenter.x
-                                translationY = tooltipCenter.y
-                            }.pointerInput(Unit) {
-                                // Prevent taps on tooltip from being handled by the canvas
-                                detectTapGestures { }
-                            },
-                    onClick = onAddRelationshipClick,
+                    p1 = p1,
+                    p2 = p2,
+                    onClick = { onEvent(TreeEvent.OnAddRelationship) },
                 )
             }
         }
     }
 }
 
-private fun DrawScope.drawPerson(
-    person: PersonNodeUi,
-    textMeasurer: TextMeasurer,
-    theme: ColorScheme,
-    typography: Typography,
-    isSelected: Boolean,
-) {
-    val nodeSize = 64.dp.toPx()
-    val center = person.position
-    val topLeft = Offset(center.x - nodeSize / 2, center.y - nodeSize / 2)
+@Composable
+private fun GridBackground(modifier: Modifier = Modifier) {
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val gridStep = 40.dp.toPx()
+        val color = Color.LightGray.copy(alpha = 0.3f)
+        val gridCount = 200 // Increased for larger canvas
+        val size = gridStep * gridCount
+        val start = -size / 2
 
-    if (isSelected) {
-        drawPersonSelection(person, nodeSize, center, topLeft, theme.primary)
+        for (i in 0..gridCount) {
+            val pos = start + i * gridStep
+            drawLine(color, Offset(pos, start), Offset(pos, start + size), 1f)
+            drawLine(color, Offset(start, pos), Offset(start + size, pos), 1f)
+        }
     }
+}
 
-    val color =
+@Composable
+private fun PersonNodeView(
+    person: PersonNodeUi,
+    isSelected: Boolean,
+    onSelected: () -> Unit,
+    onMove: (Offset) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val density = LocalDensity.current
+    val currentOnMove by rememberUpdatedState(onMove)
+    val shape =
+        if (person.biologicalSex == Person.BiologicalSex.FEMALE) {
+            CircleShape
+        } else {
+            RectangleShape
+        }
+
+    val backgroundColor =
         when (person.biologicalSex) {
             Person.BiologicalSex.MALE -> Color(0xFFD1E4FF)
             Person.BiologicalSex.FEMALE -> Color(0xFFFFD1DC)
-            else -> theme.secondary
+            else -> MaterialTheme.colorScheme.secondaryContainer
         }
 
-    drawPersonShape(person, color, nodeSize, center, topLeft)
-    drawPersonIdentityMarkers(person, nodeSize, center, topLeft)
-    drawPersonTextInfo(person, textMeasurer, typography, nodeSize, center, topLeft)
-}
-
-private fun DrawScope.drawPersonSelection(
-    person: PersonNodeUi,
-    nodeSize: Float,
-    center: Offset,
-    topLeft: Offset,
-    color: Color,
-) {
-    val selectionPadding = 4.dp.toPx()
-    val selectionSize = nodeSize + selectionPadding * 2
-    val selectionTopLeft = Offset(topLeft.x - selectionPadding, topLeft.y - selectionPadding)
-
-    when (person.biologicalSex) {
-        Person.BiologicalSex.MALE -> {
-            drawRect(
-                color = color,
-                topLeft = selectionTopLeft,
-                size = Size(selectionSize, selectionSize),
-                style = Stroke(width = 3.dp.toPx()),
-            )
-        }
-
-        Person.BiologicalSex.FEMALE -> {
-            drawCircle(
-                color = color,
-                center = center,
-                radius = selectionSize / 2,
-                style = Stroke(width = 3.dp.toPx()),
-            )
-        }
-
-        else -> {
-            drawRect(
-                color = color,
-                topLeft = selectionTopLeft,
-                size = Size(selectionSize, selectionSize),
-                style = Stroke(width = 3.dp.toPx()),
-            )
-        }
-    }
-}
-
-private fun DrawScope.drawPersonShape(
-    person: PersonNodeUi,
-    color: Color,
-    nodeSize: Float,
-    center: Offset,
-    topLeft: Offset,
-) {
-    when (person.biologicalSex) {
-        Person.BiologicalSex.MALE -> {
-            drawRect(color = color, topLeft = topLeft, size = Size(nodeSize, nodeSize))
-            drawRect(
-                color = Color.Black,
-                topLeft = topLeft,
-                size = Size(nodeSize, nodeSize),
-                style = Stroke(width = 2f),
-            )
-            if (person.isIndexPerson) {
-                val padding = 4.dp.toPx()
-                drawRect(
-                    color = Color.Black,
-                    topLeft = topLeft + Offset(padding, padding),
-                    size = Size(nodeSize - 2 * padding, nodeSize - 2 * padding),
-                    style = Stroke(width = 2f),
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+                .offset {
+                    IntOffset(
+                        (person.position.x.dp - 50.dp).roundToPx(),
+                        (person.position.y.dp - 56.dp).roundToPx(),
+                    )
+                }
+                .width(100.dp)
+                .combinedClickable(
+                    onClick = onSelected,
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() }
                 )
-            }
-        }
-
-        Person.BiologicalSex.FEMALE -> {
-            drawCircle(color = color, center = center, radius = nodeSize / 2)
-            drawCircle(
-                color = Color.Black,
-                center = center,
-                radius = nodeSize / 2,
-                style = Stroke(width = 2f),
-            )
-            if (person.isIndexPerson) {
-                val padding = 4.dp.toPx()
-                drawCircle(
-                    color = Color.Black,
-                    center = center,
-                    radius = nodeSize / 2 - padding,
-                    style = Stroke(width = 2f),
-                )
-            }
-        }
-
-        else -> {
-            drawRect(color = color, topLeft = topLeft, size = Size(nodeSize, nodeSize))
-            drawRect(
-                color = Color.Black,
-                topLeft = topLeft,
-                size = Size(nodeSize, nodeSize),
-                style = Stroke(width = 2f),
-            )
-        }
-    }
-}
-
-private fun DrawScope.drawPersonIdentityMarkers(
-    person: PersonNodeUi,
-    nodeSize: Float,
-    center: Offset,
-    topLeft: Offset,
-) {
-    if (person.sexualOrientation != Person.SexualOrientation.HETEROSEXUAL &&
-        person.sexualOrientation != Person.SexualOrientation.UNKNOWN
+                .pointerInput(person.id) {
+                    detectDragGestures { change, dragAmount ->
+                        change.consume()
+                        val deltaDp = with(density) {
+                            Offset(
+                                x = dragAmount.x.toDp().value,
+                                y = dragAmount.y.toDp().value,
+                            )
+                        }
+                        currentOnMove(deltaDp)
+                    }
+                },
     ) {
-        val trianglePath =
-            Path().apply {
-                val triangleSize = nodeSize * 0.7f
-                moveTo(center.x - triangleSize / 2, center.y - triangleSize / 3)
-                lineTo(center.x + triangleSize / 2, center.y - triangleSize / 3)
-                lineTo(center.x, center.y + triangleSize * 2 / 3)
-                close()
-            }
-        drawPath(path = trianglePath, color = Color.Black, style = Stroke(width = 2f))
-    }
-
-    if (person.isDeceased) {
-        drawLine(
-            color = Color.Black,
-            start = topLeft,
-            end = topLeft + Offset(nodeSize, nodeSize),
-            strokeWidth = 2f,
+        PersonDates(
+            birthDate = person.birthDateText,
+            deathDate = person.deathDateText,
         )
-        drawLine(
-            color = Color.Black,
-            start = topLeft + Offset(nodeSize, 0f),
-            end = topLeft + Offset(0f, nodeSize),
-            strokeWidth = 2f,
-        )
-    }
-}
 
-private fun DrawScope.drawPersonTextInfo(
-    person: PersonNodeUi,
-    textMeasurer: TextMeasurer,
-    typography: Typography,
-    nodeSize: Float,
-    center: Offset,
-    topLeft: Offset,
-) {
-    // Text: Name (below)
-    val nameResult =
-        textMeasurer.measure(
+        Spacer(modifier = Modifier.height(4.dp))
+
+        PersonShape(
+            person = person,
+            shape = shape,
+            backgroundColor = backgroundColor,
+            size = with(density) { NODE_SIZE.toPx() },
+            modifier = Modifier
+                .nodeBorder(shape, isSelected, person.isIndexPerson)
+                .background(backgroundColor, shape)
+                .size(NODE_SIZE)
+                .padding(4.dp)
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
             text = "${person.firstName} ${person.lastName}",
-            style =
-                typography.bodyMedium.copy(
-                    fontWeight = FontWeight.SemiBold,
-                    textAlign = TextAlign.Center,
-                ),
-            constraints = Constraints(maxWidth = (nodeSize * 3).toInt()),
-        )
-    drawText(
-        textLayoutResult = nameResult,
-        topLeft =
-            Offset(
-                center.x - nameResult.size.width / 2,
-                center.y + nodeSize / 2 + 8.dp.toPx(),
+            style = MaterialTheme.typography.bodyMedium.copy(
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
             ),
-    )
-
-    // Text: Birth date (top left)
-    if (person.birthDateText.isNotEmpty()) {
-        val birthResult =
-            textMeasurer.measure(
-                text = person.birthDateText,
-                style = typography.bodySmall.copy(fontSize = 10.sp),
-            )
-        drawText(
-            textLayoutResult = birthResult,
-            topLeft =
-                Offset(
-                    topLeft.x - birthResult.size.width - 4.dp.toPx(),
-                    topLeft.y - birthResult.size.height,
-                ),
-        )
-    }
-
-    // Text: Death date (top right)
-    if (person.deathDateText.isNotEmpty()) {
-        val deathResult =
-            textMeasurer.measure(
-                text = person.deathDateText,
-                style = typography.bodySmall.copy(fontSize = 10.sp),
-            )
-        drawText(
-            textLayoutResult = deathResult,
-            topLeft =
-                Offset(
-                    topLeft.x + nodeSize + 4.dp.toPx(),
-                    topLeft.y - deathResult.size.height,
-                ),
-        )
-    }
-
-    // Text: Age (inside)
-    if (person.age.isNotEmpty()) {
-        val ageResult =
-            textMeasurer.measure(
-                text = person.age,
-                style =
-                    typography.bodySmall.copy(
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Bold,
-                        textAlign = TextAlign.Center,
-                    ),
-            )
-        drawText(
-            textLayoutResult = ageResult,
-            topLeft =
-                Offset(
-                    center.x - ageResult.size.width / 2,
-                    center.y - ageResult.size.height / 2,
-                ),
+            textAlign = TextAlign.Center,
+            maxLines = 2,
         )
     }
 }
 
 @Composable
+private fun PersonDates(
+    birthDate: String,
+    deathDate: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        if (birthDate.isNotEmpty()) {
+            Text(
+                text = birthDate,
+                style = MaterialTheme.typography.bodySmall.copy(fontSize = 10.sp),
+            )
+        }
+        if (birthDate.isNotEmpty() && deathDate.isNotEmpty()) {
+            Text(text = "-", modifier = Modifier)
+        }
+        if (deathDate.isNotEmpty()) {
+            Text(
+                text = deathDate,
+                style = MaterialTheme.typography.bodySmall.copy(fontSize = 10.sp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PersonShape(
+    person: PersonNodeUi,
+    shape: Shape,
+    backgroundColor: Color,
+    size: Float,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        if (person.isDeceased) {
+            Canvas(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(if (shape == CircleShape) 6.dp else 0.dp)
+            ) {
+                drawDeathMark()
+            }
+        }
+        if (person.sexualOrientation == Person.SexualOrientation.OTHER) {
+            Canvas(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(if (shape == CircleShape) 6.dp else 0.dp)
+            ) {
+                drawSexualOrientationMark(nodeSize = size)
+            }
+        }
+
+        if (person.age.isNotEmpty()) {
+            Text(
+                text = person.age,
+                style = MaterialTheme.typography.bodySmall.copy(
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center,
+                ),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.background(backgroundColor)
+            )
+        }
+    }
+}
+
+private fun DrawScope.drawDeathMark() {
+    drawLine(
+        color = Color.Black,
+        start = Offset.Zero,
+        end = Offset(size.width, size.height),
+        strokeWidth = 4f
+    )
+    drawLine(
+        color = Color.Black,
+        start = Offset(size.width, 0f),
+        end = Offset(0f, size.height),
+        strokeWidth = 4f
+    )
+}
+
+private fun DrawScope.drawSexualOrientationMark(nodeSize: Float) {
+    val trianglePath = Path().apply {
+        val triangleSize = nodeSize * 0.7f
+        moveTo(center.x - triangleSize / 2, center.y - triangleSize / 3)
+        lineTo(center.x + triangleSize / 2, center.y - triangleSize / 3)
+        lineTo(center.x, center.y + triangleSize * 2 / 3)
+        close()
+    }
+    drawPath(
+        path = trianglePath,
+        color = Color.Black,
+        style = Stroke(width = 2f),
+    )
+}
+
+@Composable
 private fun RelationshipTooltip(
+    p1: PersonNodeUi?,
+    p2: PersonNodeUi?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val density = LocalDensity.current
-    val halfWidthPx = with(density) { 60.dp.toPx() }
-    val halfHeightPx = with(density) { 16.dp.toPx() }
+    if (p1 != null && p2 != null) {
+        val tooltipCenter = (p1.position + p2.position) / 2f
 
-    Surface(
-        onClick = onClick,
-        modifier =
-            modifier
-                .height(32.dp)
-                .graphicsLayer {
-                    translationX -= halfWidthPx
-                    translationY -= halfHeightPx
-                },
-        shape = RoundedCornerShape(16.dp),
-        color = Color.White,
-        shadowElevation = 4.dp,
-    ) {
-        Box(
-            modifier = Modifier.padding(horizontal = 12.dp),
-            contentAlignment = Alignment.Center,
+        Surface(
+            onClick = onClick,
+            modifier =
+                modifier
+                    .offset(tooltipCenter.x.dp, tooltipCenter.y.dp)
+                    .layout { measurable, constraints ->
+                        val placeable = measurable.measure(constraints)
+                        layout(placeable.width, placeable.height) {
+                            placeable.placeRelative(-placeable.width / 2, -placeable.height / 2)
+                        }
+                    }
+                    .pointerInput(Unit) {
+                        // Prevent taps on tooltip from being handled by the canvas
+                        detectTapGestures { }
+                    }
+                    .height(32.dp),
+            shape = RoundedCornerShape(16.dp),
+            color = Color.White,
+            shadowElevation = 4.dp,
         ) {
-            Text(
-                text = stringResource(Res.string.add_relationship),
-                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
-                color = Color.Black,
-            )
+            Box(
+                modifier = Modifier.padding(horizontal = 12.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(Res.string.add_relationship),
+                    style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
+                    color = Color.Black,
+                    softWrap = false,
+                )
+            }
         }
     }
 }
@@ -734,6 +657,38 @@ private fun CanvasControls(
     }
 }
 
+@Composable
+private fun Modifier.nodeBorder(
+    shape: Shape,
+    isSelected: Boolean,
+    isIndex: Boolean,
+) = this
+    .then(
+        if (isSelected) {
+            Modifier.border(
+                width = 2.dp,
+                color = MaterialTheme.colorScheme.primary,
+                shape = shape,
+            )
+        } else Modifier
+    )
+    .padding(4.dp)
+    .then(
+        if (isIndex) {
+            Modifier.border(shape).padding(4.dp)
+        } else Modifier
+    )
+    .border(shape)
+
+@Composable
+private fun Modifier.border(shape: Shape) = border(
+    width = 1.dp,
+    color = Color.Black,
+    shape = shape,
+)
+
+private val NODE_SIZE = 64.dp
+
 private class TreeStateProvider : PreviewParameterProvider<TreeState> {
     private val seed =
         TreeUi(
@@ -749,7 +704,7 @@ private class TreeStateProvider : PreviewParameterProvider<TreeState> {
                     birthDateText = "1980",
                     age = "44",
                     isIndexPerson = true,
-                    position = Offset(500f, 750f),
+                    position = Offset(100f, 100f),
                 ),
             persons =
                 listOf(
@@ -762,7 +717,7 @@ private class TreeStateProvider : PreviewParameterProvider<TreeState> {
                         deathDateText = "1989",
                         age = "74",
                         isDeceased = true,
-                        position = Offset(500f, 400f),
+                        position = Offset(300f, 100f),
                     ),
                     PersonNodeUi(
                         id = "3",
@@ -772,7 +727,7 @@ private class TreeStateProvider : PreviewParameterProvider<TreeState> {
                         sexualOrientation = Person.SexualOrientation.OTHER,
                         birthDateText = "2001",
                         age = "25",
-                        position = Offset(500f, 1100f),
+                        position = Offset(75f, 500f),
                     ),
                     PersonNodeUi(
                         id = "4",
@@ -784,7 +739,7 @@ private class TreeStateProvider : PreviewParameterProvider<TreeState> {
                         deathDateText = "2021",
                         age = "31",
                         isDeceased = true,
-                        position = Offset(500f, 1500f),
+                        position = Offset(225f, 300f),
                     ),
                 ),
         )
@@ -792,6 +747,10 @@ private class TreeStateProvider : PreviewParameterProvider<TreeState> {
     override val values =
         sequenceOf(
             TreeState(tree = seed),
+            TreeState(
+                tree = seed,
+                selectedPersonIds = listOf("3", "4"),
+            ),
             TreeState(
                 tree = seed,
                 scale = 3f,

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeState.kt
@@ -9,7 +9,7 @@ data class TreeState(
     val isLoading: Boolean = false,
     val error: TreeError? = null,
     val shouldNavigateBack: Boolean = false,
-    val selectedPersonId: String? = null,
+    val selectedPersonIds: List<String> = emptyList(),
 )
 
 enum class TreeError {

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
@@ -65,11 +65,26 @@ class TreeViewModel(
             }
 
             is TreeEvent.OnPersonSelected -> {
-                _state.update { it.copy(selectedPersonId = event.personId) }
+                _state.update {
+                    val currentSelected = it.selectedPersonIds
+                    val newSelected =
+                        if (currentSelected.contains(event.personId)) {
+                            currentSelected - event.personId
+                        } else if (currentSelected.size < 2) {
+                            currentSelected + event.personId
+                        } else {
+                            listOf(event.personId)
+                        }
+                    it.copy(selectedPersonIds = newSelected)
+                }
             }
 
             TreeEvent.OnDismissSelection -> {
-                _state.update { it.copy(selectedPersonId = null) }
+                _state.update { it.copy(selectedPersonIds = emptyList()) }
+            }
+
+            TreeEvent.OnAddRelationship -> {
+                // To be implemented in US-020
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
@@ -48,10 +48,13 @@ class TreeViewModel(
 
             is TreeEvent.OnTransform -> {
                 _state.update {
-                    val newScale = (it.scale * event.zoom).coerceIn(0.1f, 3f)
+                    val oldScale = it.scale
+                    val newScale = (oldScale * event.zoom).coerceIn(0.1f, 3f)
+                    val actualZoom = newScale / oldScale
+                    val newOffset = event.centroid + (it.offset - event.centroid) * actualZoom + event.pan
                     it.copy(
                         scale = newScale,
-                        offset = it.offset + event.pan,
+                        offset = newOffset,
                     )
                 }
             }
@@ -85,6 +88,32 @@ class TreeViewModel(
 
             TreeEvent.OnAddRelationship -> {
                 // To be implemented in US-020
+            }
+
+            is TreeEvent.OnPersonMove -> {
+                _state.update { state ->
+                    val updatedCentralPerson =
+                        if (state.tree.centralPerson.id == event.personId) {
+                            state.tree.centralPerson.copy(position = state.tree.centralPerson.position + event.delta)
+                        } else {
+                            state.tree.centralPerson
+                        }
+                    val updatedPersons =
+                        state.tree.persons.map { person ->
+                            if (person.id == event.personId) {
+                                person.copy(position = person.position + event.delta)
+                            } else {
+                                person
+                            }
+                        }
+                    state.copy(
+                        tree =
+                            state.tree.copy(
+                                centralPerson = updatedCentralPerson,
+                                persons = updatedPersons,
+                            ),
+                    )
+                }
             }
         }
     }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/registration/RegistrationViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/registration/RegistrationViewModelTest.kt
@@ -6,6 +6,8 @@ import dev.saragones3.genogramia.domain.usecase.SignUpUseCase
 import dev.saragones3.genogramia.fakes.FakeAuthRepository
 import genogramia.composeapp.generated.resources.Res
 import genogramia.composeapp.generated.resources.error_email_already_in_use
+import genogramia.composeapp.generated.resources.error_invalid_email
+import genogramia.composeapp.generated.resources.error_invalid_password
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -157,6 +159,34 @@ class RegistrationViewModelTest {
         }
 
     @Test
+    fun `when email is invalid general error is updated`() =
+        runTest {
+            repository.shouldReturnError = true
+            repository.errorToReturn = AuthError.InvalidEmail
+            viewModel.onEvent(RegistrationEvent.OnDataChanged("Test User", "test@example.com", "password123"))
+
+            viewModel.onEvent(RegistrationEvent.OnSignUpClicked)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertEquals(Res.string.error_invalid_email, state.generalError)
+        }
+
+    @Test
+    fun `when password is weak general error is updated`() =
+        runTest {
+            repository.shouldReturnError = true
+            repository.errorToReturn = AuthError.WeakPassword
+            viewModel.onEvent(RegistrationEvent.OnDataChanged("Test User", "test@example.com", "password123"))
+
+            viewModel.onEvent(RegistrationEvent.OnSignUpClicked)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertEquals(Res.string.error_invalid_password, state.generalError)
+        }
+
+    @Test
     fun `registrationSuccessConsumed resets state`() =
         runTest {
             viewModel.onEvent(RegistrationEvent.OnDataChanged("Test User", "test@example.com", "password123"))
@@ -167,5 +197,55 @@ class RegistrationViewModelTest {
             assertEquals("", state.name)
             assertEquals("", state.email)
             assertFalse(state.isRegistrationSuccess)
+        }
+
+    @Test
+    fun `when password is too short validation fails`() =
+        runTest {
+            viewModel.onEvent(RegistrationEvent.OnDataChanged("Test", "test@example.com", "short"))
+            viewModel.onEvent(RegistrationEvent.OnSignUpClicked)
+
+            val state = viewModel.state.value
+            assertEquals(RegistrationState.ValidationError.INVALID, state.passwordError)
+        }
+
+    @Test
+    fun `when password is corrected after invalid length error is cleared`() =
+        runTest {
+            // Given an invalid password state
+            viewModel.onEvent(RegistrationEvent.OnDataChanged("Test", "test@example.com", "short"))
+            viewModel.onEvent(RegistrationEvent.OnSignUpClicked)
+            assertEquals(RegistrationState.ValidationError.INVALID, viewModel.state.value.passwordError)
+
+            // When the password is corrected
+            viewModel.onEvent(RegistrationEvent.OnDataChanged("Test", "test@example.com", "password123"))
+
+            // Then the error is cleared
+            assertNull(viewModel.state.value.passwordError)
+        }
+
+    @Test
+    fun `when name is empty validation fails`() =
+        runTest {
+            viewModel.onEvent(RegistrationEvent.OnDataChanged("", "test@example.com", "password123"))
+            viewModel.onEvent(RegistrationEvent.OnSignUpClicked)
+
+            val state = viewModel.state.value
+            assertEquals(RegistrationState.ValidationError.EMPTY, state.nameError)
+        }
+
+    @Test
+    fun `when name is corrected after empty error is cleared`() =
+        runTest {
+            // Given an empty name state
+            viewModel.onEvent(RegistrationEvent.OnDataChanged("", "test@example.com", "password123"))
+            viewModel.onEvent(RegistrationEvent.OnSignUpClicked)
+            assertEquals(RegistrationState.ValidationError.EMPTY, viewModel.state.value.nameError)
+
+            // When the name is corrected
+            viewModel.onEvent(RegistrationEvent.OnDataChanged("Test", "test@example.com", "password123"))
+
+            // Then the error is cleared
+            assertNull(viewModel.state.value.nameError)
         }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
@@ -177,17 +177,43 @@ class TreeViewModelTest {
         }
 
     @Test
-    fun `when OnPersonSelected event is received selectedPersonId is updated`() =
+    fun `when OnPersonSelected event is received selectedPersonIds is updated`() =
         runTest {
             viewModel.onEvent(TreeEvent.OnPersonSelected("p1"))
-            assertEquals("p1", viewModel.state.value.selectedPersonId)
+            assertEquals(listOf("p1"), viewModel.state.value.selectedPersonIds)
         }
 
     @Test
-    fun `when OnDismissSelection event is received selectedPersonId is cleared`() =
+    fun `when two OnPersonSelected events are received for different persons both are selected`() =
+        runTest {
+            viewModel.onEvent(TreeEvent.OnPersonSelected("p1"))
+            viewModel.onEvent(TreeEvent.OnPersonSelected("p2"))
+            assertEquals(listOf("p1", "p2"), viewModel.state.value.selectedPersonIds)
+        }
+
+    @Test
+    fun `when OnPersonSelected is called on already selected person it is deselected`() =
+        runTest {
+            viewModel.onEvent(TreeEvent.OnPersonSelected("p1"))
+            viewModel.onEvent(TreeEvent.OnPersonSelected("p2"))
+            viewModel.onEvent(TreeEvent.OnPersonSelected("p1"))
+            assertEquals(listOf("p2"), viewModel.state.value.selectedPersonIds)
+        }
+
+    @Test
+    fun `when third person is selected only the new one remains selected`() =
+        runTest {
+            viewModel.onEvent(TreeEvent.OnPersonSelected("p1"))
+            viewModel.onEvent(TreeEvent.OnPersonSelected("p2"))
+            viewModel.onEvent(TreeEvent.OnPersonSelected("p3"))
+            assertEquals(listOf("p3"), viewModel.state.value.selectedPersonIds)
+        }
+
+    @Test
+    fun `when OnDismissSelection event is received selectedPersonIds is cleared`() =
         runTest {
             viewModel.onEvent(TreeEvent.OnPersonSelected("p1"))
             viewModel.onEvent(TreeEvent.OnDismissSelection)
-            assertNull(viewModel.state.value.selectedPersonId)
+            assertEquals(emptyList<String>(), viewModel.state.value.selectedPersonIds)
         }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
@@ -145,10 +145,11 @@ class TreeViewModelTest {
     @Test
     fun `when OnTransform event is received scale and offset are updated`() =
         runTest {
+            val centroid = androidx.compose.ui.geometry.Offset.Zero
             val pan =
                 androidx.compose.ui.geometry
                     .Offset(10f, 20f)
-            viewModel.onEvent(TreeEvent.OnTransform(pan, 1.1f))
+            viewModel.onEvent(TreeEvent.OnTransform(centroid, pan, 1.1f))
 
             val state = viewModel.state.value
             assertEquals(10f, state.offset.x)
@@ -215,5 +216,24 @@ class TreeViewModelTest {
             viewModel.onEvent(TreeEvent.OnPersonSelected("p1"))
             viewModel.onEvent(TreeEvent.OnDismissSelection)
             assertEquals(emptyList<String>(), viewModel.state.value.selectedPersonIds)
+        }
+
+    @Test
+    fun `when OnPersonMove event is received person position is updated`() =
+        runTest {
+            val central = Person("p1", "John", "Doe", 0L)
+            val tree = GenogramTree("t1", "Family", 1, "now", central)
+            treeRepository.createTree(tree)
+
+            viewModel.onEvent(TreeEvent.LoadTree("t1"))
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val initialPos = viewModel.state.value.tree.centralPerson.position
+            val delta =
+                androidx.compose.ui.geometry
+                    .Offset(10f, 20f)
+            viewModel.onEvent(TreeEvent.OnPersonMove("p1", delta))
+
+            assertEquals(initialPos + delta, viewModel.state.value.tree.centralPerson.position)
         }
 }


### PR DESCRIPTION
This PR implements multi-selection and relationship UI in Genogram canvas as part of US-019.

### Changes
- Updated \TreeState\ to support a list of selected person IDs.
- Configured \TreeViewModel\ to handle multi-selection logic (up to 2 selected nodes).
- Added visual feedback on the Canvas with a dashed teal line linking the two selected person nodes.
- Created a floating \RelationshipTooltip\ in \TreeScreen\ at the midpoint between the two selected nodes.
- Added translation strings for 'Añadir relación' / 'Add relationship' in English and Spanish.
- Wrote comprehensive unit tests in \TreeViewModelTest\ to cover the new multi-selection state transition rules.

Fixes #60