### PR TITLE
[US-021] User taps on a relationship line

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -156,6 +156,7 @@
     <string name="edit_person_title">Editar Familiar</string>
     <string name="add_person_save">Guardar Registro de Miembro</string>
     <string name="add_relationship">Añadir relación</string>
+    <string name="edit_relationship">Editar relación</string>
 
     <!-- Add Relationship -->
     <string name="add_relationship_title">Añadir Relación</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -156,6 +156,7 @@
     <string name="edit_person_title">Edit Family Member</string>
     <string name="add_person_save">Save Member Record</string>
     <string name="add_relationship">Add relationship</string>
+    <string name="edit_relationship">Edit relationship</string>
 
     <!-- Add Relationship -->
     <string name="add_relationship_title">Add Relationship</string>

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/util/RealDateProvider.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/util/RealDateProvider.kt
@@ -2,9 +2,12 @@ package dev.saragones3.genogramia.data.util
 
 import dev.saragones3.genogramia.domain.util.DateProvider
 import kotlin.time.Clock
+import kotlin.time.Instant
 
 class RealDateProvider(
     private val clock: Clock = Clock.System,
 ) : DateProvider {
     override fun nowEpochMilliseconds(): Long = clock.now().toEpochMilliseconds()
+
+    override fun now(): Instant = clock.now()
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/model/Relationship.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/model/Relationship.kt
@@ -23,6 +23,9 @@ data class Relationship(
 
         val isStructural: Boolean
             get() = this in listOf(MARRIAGE, COHABITATION, SEPARATION, DIVORCE, RECONCILIATION)
+
+        val isDescendant: Boolean
+            get() = this in listOf(BIOLOGICAL_OFFSPRING, ADOPTION_LEGAL)
     }
 
     enum class EmotionalBond {

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/AddRelationshipUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/AddRelationshipUseCase.kt
@@ -11,7 +11,7 @@ class AddRelationshipUseCase(
         relationship: Relationship,
     ) {
         val tree = repository.getTree(treeId) ?: return
-        val updatedRelationships = tree.relationships + relationship
+        val updatedRelationships = tree.relationships.filter { it.id != relationship.id } + relationship
         repository.updateTree(tree.copy(relationships = updatedRelationships))
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/util/DateProvider.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/util/DateProvider.kt
@@ -1,5 +1,9 @@
 package dev.saragones3.genogramia.domain.util
 
+import kotlin.time.Instant
+
 interface DateProvider {
     fun nowEpochMilliseconds(): Long
+
+    fun now(): Instant
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipScreen.kt
@@ -113,21 +113,23 @@ import genogramia.composeapp.generated.resources.add_relationship_separation
 import genogramia.composeapp.generated.resources.add_relationship_swap_roles
 import genogramia.composeapp.generated.resources.add_relationship_title
 import genogramia.composeapp.generated.resources.date_format
+import genogramia.composeapp.generated.resources.edit_relationship
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun AddRelationshipScreen(
     treeId: String,
-    personId1: String,
-    personId2: String,
+    personId1: String? = null,
+    personId2: String? = null,
+    relationshipId: String? = null,
     onBackClick: () -> Unit,
 ) {
     val viewModel: AddRelationshipViewModel = koinViewModel()
     val state by viewModel.state.collectAsState()
 
-    LaunchedEffect(treeId, personId1, personId2) {
-        viewModel.onResume(treeId, personId1, personId2)
+    LaunchedEffect(treeId, personId1, personId2, relationshipId) {
+        viewModel.onResume(treeId, personId1, personId2, relationshipId)
     }
 
     LaunchedEffect(state.shouldNavigateBack) {
@@ -158,7 +160,14 @@ private fun AddRelationshipContent(
             CenterAlignedTopAppBar(
                 title = {
                     Text(
-                        text = stringResource(Res.string.add_relationship_title),
+                        text =
+                            stringResource(
+                                if (state.relationshipId != null) {
+                                    Res.string.edit_relationship
+                                } else {
+                                    Res.string.add_relationship_title
+                                },
+                            ),
                         style = MaterialTheme.typography.titleLarge,
                         fontWeight = FontWeight.Bold,
                     )

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipScreen.kt
@@ -313,14 +313,18 @@ private fun RelationshipManagerCard(
                             .height(72.dp), // Same as icon size
                 ) {
                     val iconCenterY = 36.dp.toPx()
-                    val iconCenterXOffset = 72.dp.toPx()
+                    val swapButtonSize = 32.dp.toPx()
+                    val nodeWidth = (size.width - swapButtonSize) / 2
+                    val startX = nodeWidth / 2
+                    val endX = size.width - (nodeWidth / 2)
+
                     val dashWidth = 6.dp.toPx()
                     val dashGap = 4.dp.toPx()
 
                     drawLine(
                         color = Color(0xFF008080),
-                        start = Offset(iconCenterXOffset, iconCenterY),
-                        end = Offset(size.width - iconCenterXOffset, iconCenterY),
+                        start = Offset(startX, iconCenterY),
+                        end = Offset(endX, iconCenterY),
                         strokeWidth = 2.dp.toPx(),
                         pathEffect = PathEffect.dashPathEffect(floatArrayOf(dashWidth, dashGap), 0f),
                     )

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipState.kt
@@ -10,6 +10,7 @@ data class AddRelationshipState(
     val effectiveDate: Long? = null,
     val effectiveDateFormatted: String? = null,
     val hasConsanguinityRisk: Boolean = false,
+    val relationshipId: String? = null,
     val isLoading: Boolean = false,
     val isSaving: Boolean = false,
     val error: String? = null,

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModel.kt
@@ -33,16 +33,6 @@ class AddRelationshipViewModel(
         personId2: String?,
         relationshipId: String? = null,
     ) {
-        // Prevent re-loading if already loaded data for this tree and mode (add/edit)
-        val currentState = _state.value
-        if (this.treeId == treeId &&
-            currentState.relationshipId == relationshipId &&
-            currentState.person1 != null &&
-            !currentState.isLoading
-        ) {
-            return
-        }
-
         this.treeId = treeId
         // Preserve current state bondType if we are just recomposing,
         // but since this is onResume (entry point), we typically want to load.
@@ -93,7 +83,7 @@ class AddRelationshipViewModel(
                                 }.map { it.personId1 }
                                 .toSet()
 
-                        p1Parents.intersect(p2Parents).isNotEmpty()
+                        p1Parents.intersect(p2Parents).isNotEmpty() || p2Parents.intersect(p1Parents).isNotEmpty()
                     } else {
                         false
                     }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModel.kt
@@ -29,46 +29,93 @@ class AddRelationshipViewModel(
 
     fun onResume(
         treeId: String,
-        personId1: String,
-        personId2: String,
+        personId1: String?,
+        personId2: String?,
+        relationshipId: String? = null,
     ) {
+        // Prevent re-loading if already loaded data for this tree and mode (add/edit)
+        val currentState = _state.value
+        if (this.treeId == treeId &&
+            currentState.relationshipId == relationshipId &&
+            currentState.person1 != null &&
+            !currentState.isLoading
+        ) {
+            return
+        }
+
         this.treeId = treeId
-        _state.value = AddRelationshipState(isLoading = true)
+        // Preserve current state bondType if we are just recomposing,
+        // but since this is onResume (entry point), we typically want to load.
+        _state.update { it.copy(isLoading = true, relationshipId = relationshipId) }
+
         viewModelScope.launch {
-            val tree = getTreeUseCase(treeId)
-            val p1 = getPersonUseCase(treeId, personId1)
-            val p2 = getPersonUseCase(treeId, personId2)
+            try {
+                val tree = getTreeUseCase(treeId)
 
-            val hasConsanguinity =
-                if ((tree != null) && (p1 != null) && (p2 != null)) {
-                    val p1Parents =
-                        tree.relationships
-                            .asSequence()
-                            .filter {
-                                it.type == Relationship.RelationshipType.BIOLOGICAL_OFFSPRING && it.personId2 == p1.id
-                            }.map { it.personId1 }
-                            .toSet()
+                var finalP1Id = personId1
+                var finalP2Id = personId2
+                var bondType = Relationship.RelationshipType.MARRIAGE
+                var emotionalBond = Relationship.EmotionalBond.POSITIVE
+                var effectiveDate: Long? = null
 
-                    val p2Parents =
-                        tree.relationships
-                            .asSequence()
-                            .filter {
-                                it.type == Relationship.RelationshipType.BIOLOGICAL_OFFSPRING && it.personId2 == p2.id
-                            }.map { it.personId1 }
-                            .toSet()
-
-                    p1Parents.intersect(p2Parents).isNotEmpty()
-                } else {
-                    false
+                if (relationshipId != null && tree != null) {
+                    val rel = tree.relationships.find { it.id == relationshipId }
+                    if (rel != null) {
+                        finalP1Id = rel.personId1
+                        finalP2Id = rel.personId2
+                        bondType = rel.type
+                        emotionalBond = rel.emotionalBond
+                        effectiveDate = rel.effectiveDate
+                    }
                 }
 
-            _state.update {
-                it.copy(
-                    person1 = p1?.toUi(),
-                    person2 = p2?.toUi(),
-                    isLoading = false,
-                    hasConsanguinityRisk = hasConsanguinity,
-                )
+                // If we don't have IDs from relationship, use the ones passed from navigation
+                val p1 = finalP1Id?.let { getPersonUseCase(treeId, it) }
+                val p2 = finalP2Id?.let { getPersonUseCase(treeId, it) }
+
+                val hasConsanguinity =
+                    if ((tree != null) && (p1 != null) && (p2 != null)) {
+                        val p1Parents =
+                            tree.relationships
+                                .asSequence()
+                                .filter {
+                                    it.type == Relationship.RelationshipType.BIOLOGICAL_OFFSPRING &&
+                                        it.personId2 == p1.id
+                                }.map { it.personId1 }
+                                .toSet()
+
+                        val p2Parents =
+                            tree.relationships
+                                .asSequence()
+                                .filter {
+                                    it.type == Relationship.RelationshipType.BIOLOGICAL_OFFSPRING &&
+                                        it.personId2 == p2.id
+                                }.map { it.personId1 }
+                                .toSet()
+
+                        p1Parents.intersect(p2Parents).isNotEmpty()
+                    } else {
+                        false
+                    }
+
+                _state.update {
+                    it.copy(
+                        person1 = p1?.toUi(),
+                        person2 = p2?.toUi(),
+                        bondType = bondType,
+                        emotionalBond = emotionalBond,
+                        effectiveDate = effectiveDate,
+                        effectiveDateFormatted =
+                            effectiveDate?.let { date ->
+                                dateFormatter.formatDate(date, "MM/dd/yyyy").uppercase()
+                            },
+                        isLoading = false,
+                        hasConsanguinityRisk = hasConsanguinity,
+                        relationshipId = relationshipId,
+                    )
+                }
+            } catch (e: Exception) {
+                _state.update { it.copy(isLoading = false, error = e.message) }
             }
         }
     }
@@ -128,7 +175,7 @@ class AddRelationshipViewModel(
             try {
                 val relationship =
                     Relationship(
-                        id = "${p1.id}_${p2.id}_${dateProvider.nowEpochMilliseconds()}",
+                        id = currentState.relationshipId ?: "${p1.id}_${p2.id}_${dateProvider.nowEpochMilliseconds()}",
                         personId1 = p1.id,
                         personId2 = p2.id,
                         type = currentState.bondType,

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavGraph.kt
@@ -193,6 +193,9 @@ private fun NavGraphContent(
                 onAddRelationshipClick = { treeId, p1, p2 ->
                     backStack.push(NavRoute.AddRelationship(treeId, p1, p2))
                 },
+                onEditRelationshipClick = { treeId, relId, p1, p2 ->
+                    backStack.push(NavRoute.AddRelationship(treeId, p1, p2, relId))
+                },
             )
         }
 
@@ -210,6 +213,7 @@ private fun NavGraphContent(
                 treeId = key.treeId,
                 personId1 = key.personId1,
                 personId2 = key.personId2,
+                relationshipId = key.relationshipId,
                 onBackClick = { backStack.pop() },
             )
         }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavRoute.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/navigation/NavRoute.kt
@@ -50,7 +50,8 @@ sealed interface NavRoute {
     @Serializable
     data class AddRelationship(
         val treeId: String,
-        val personId1: String,
-        val personId2: String,
+        val personId1: String? = null,
+        val personId2: String? = null,
+        val relationshipId: String? = null,
     ) : NavRoute
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeEvent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeEvent.kt
@@ -41,8 +41,6 @@ sealed interface TreeEvent {
 
     data object OnDismissSelection : TreeEvent
 
-    data object OnAddRelationship : TreeEvent
-
     data class OnPersonMove(
         val personId: String,
         val delta: Offset,

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
@@ -84,6 +84,7 @@ import genogramia.composeapp.generated.resources.add_relationship
 import genogramia.composeapp.generated.resources.canvas_reset
 import genogramia.composeapp.generated.resources.canvas_zoom_in
 import genogramia.composeapp.generated.resources.canvas_zoom_out
+import genogramia.composeapp.generated.resources.edit_relationship
 import genogramia.composeapp.generated.resources.error_tree_not_found
 import genogramia.composeapp.generated.resources.error_unknown
 import org.jetbrains.compose.resources.stringResource
@@ -95,6 +96,7 @@ fun TreeScreen(
     onBackClick: () -> Unit,
     onAddPersonClick: (String, String?) -> Unit,
     onAddRelationshipClick: (String, String, String) -> Unit,
+    onEditRelationshipClick: (String, String, String, String) -> Unit,
 ) {
     val viewModel: TreeViewModel = koinViewModel()
     val state by viewModel.state.collectAsState()
@@ -133,6 +135,9 @@ fun TreeScreen(
         onAddPersonClick = { onAddPersonClick(treeId, null) },
         onEditPersonClick = { personId -> onAddPersonClick(treeId, personId) },
         onAddRelationshipClick = { p1, p2 -> onAddRelationshipClick(treeId, p1, p2) },
+        onEditRelationshipClick = { relId, p1Id, p2Id ->
+            onEditRelationshipClick(treeId, relId, p1Id, p2Id)
+        },
         snackbarHostState = snackbarHostState,
     )
 }
@@ -145,6 +150,7 @@ private fun TreeContent(
     onAddPersonClick: () -> Unit,
     onEditPersonClick: (String) -> Unit,
     onAddRelationshipClick: (String, String) -> Unit,
+    onEditRelationshipClick: (String, String, String) -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
     Scaffold(
@@ -217,6 +223,7 @@ private fun TreeContent(
                 state = state,
                 onEvent = onEvent,
                 onAddRelationshipClick = onAddRelationshipClick,
+                onEditRelationshipClick = onEditRelationshipClick,
             )
 
             CanvasControls(
@@ -270,6 +277,7 @@ private fun GenogramCanvas(
     state: TreeState,
     onEvent: (TreeEvent) -> Unit,
     onAddRelationshipClick: (String, String) -> Unit,
+    onEditRelationshipClick: (String, String, String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val persons = remember(state.tree) { listOf(state.tree.centralPerson) + state.tree.persons }
@@ -363,9 +371,14 @@ private fun GenogramCanvas(
                 RelationshipTooltip(
                     p1 = p1,
                     p2 = p2,
+                    isEdit = state.selectedRelationshipId != null,
                     onClick = {
                         if (p1 != null && p2 != null) {
-                            onAddRelationshipClick(p1.id, p2.id)
+                            if (state.selectedRelationshipId != null) {
+                                onEditRelationshipClick(state.selectedRelationshipId, p1.id, p2.id)
+                            } else {
+                                onAddRelationshipClick(p1.id, p2.id)
+                            }
                         }
                     },
                 )
@@ -730,6 +743,7 @@ private fun DrawScope.drawSexualOrientationMark(nodeSize: Float) {
 private fun RelationshipTooltip(
     p1: PersonNodeUi?,
     p2: PersonNodeUi?,
+    isEdit: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -759,7 +773,10 @@ private fun RelationshipTooltip(
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
-                    text = stringResource(Res.string.add_relationship),
+                    text =
+                        stringResource(
+                            if (isEdit) Res.string.edit_relationship else Res.string.add_relationship,
+                        ),
                     style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
                     color = Color.Black,
                     softWrap = false,
@@ -1045,6 +1062,7 @@ private fun TreeScreenPreview(
             onAddPersonClick = {},
             onEditPersonClick = {},
             onAddRelationshipClick = { _, _ -> },
+            onEditRelationshipClick = { _, _, _ -> },
             snackbarHostState = remember { SnackbarHostState() },
         )
     }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
@@ -476,7 +476,7 @@ private fun DrawScope.drawVerticalRelationship(
 ) {
     val groupedByChild =
         relationships
-            .filter { it.type == Relationship.RelationshipType.BIOLOGICAL_OFFSPRING }
+            .filter { it.type.isDescendant }
             .groupBy { it.personId2 }
     groupedByChild.forEach { (childId, parents) ->
         val child = persons.find { it.id == childId } ?: return@forEach
@@ -514,14 +514,30 @@ private fun DrawScope.drawVerticalRelationship(
                         lineTo(childTop.x, midY)
                         lineTo(childTop.x, childTop.y)
                     }
+
+                val isAdoption = parents.any { it.type == Relationship.RelationshipType.ADOPTION_LEGAL }
+
                 drawPath(
                     path = path,
                     color = LINE_COLOR,
-                    style = Stroke(width = LINE_WIDTH.toPx()),
+                    style =
+                        Stroke(
+                            width = LINE_WIDTH.toPx(),
+                            pathEffect =
+                                if (isAdoption) {
+                                    PathEffect.dashPathEffect(
+                                        floatArrayOf(10f, 10f),
+                                        0f,
+                                    )
+                                } else {
+                                    null
+                                },
+                        ),
                 )
             }
         } else if (parents.size == 1) {
-            val parent = persons.find { it.id == parents.first().personId1 }!!
+            val rel = parents.first()
+            val parent = persons.find { it.id == rel.personId1 }!!
             val pCenter = parent.position * density
             val pBottomY = pCenter.y + nodeSize / 2
             val path =
@@ -529,10 +545,17 @@ private fun DrawScope.drawVerticalRelationship(
                     moveTo(pCenter.x, pBottomY)
                     lineTo(childTop.x, childTop.y)
                 }
+
+            val isAdoption = rel.type == Relationship.RelationshipType.ADOPTION_LEGAL
+
             drawPath(
                 path = path,
                 color = LINE_COLOR,
-                style = Stroke(width = LINE_WIDTH.toPx()),
+                style =
+                    Stroke(
+                        width = LINE_WIDTH.toPx(),
+                        pathEffect = if (isAdoption) PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f) else null,
+                    ),
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeState.kt
@@ -10,6 +10,7 @@ data class TreeState(
     val error: TreeError? = null,
     val shouldNavigateBack: Boolean = false,
     val selectedPersonIds: List<String> = emptyList(),
+    val selectedRelationshipId: String? = null,
 )
 
 enum class TreeError {

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
@@ -29,6 +29,38 @@ class TreeViewModel(
                 loadTree(event.id)
             }
 
+            is TreeEvent.OnZoomIn,
+            is TreeEvent.OnZoomOut,
+            TreeEvent.OnResetViewport,
+            is TreeEvent.OnResetToCenter,
+            is TreeEvent.OnPan,
+            is TreeEvent.OnTransform,
+            -> {
+                handleTransformation(event)
+            }
+
+            TreeEvent.OnNavigationConsumed,
+            TreeEvent.OnErrorConsumed,
+            -> {
+                handleSystemEvents(event)
+            }
+
+            is TreeEvent.OnPersonSelected,
+            TreeEvent.OnDismissSelection,
+            -> {
+                handleSelection(event)
+            }
+
+            is TreeEvent.OnPersonMove,
+            is TreeEvent.OnPersonMoveFinished,
+            -> {
+                handlePersonMovement(event)
+            }
+        }
+    }
+
+    private fun handleTransformation(event: TreeEvent) {
+        when (event) {
             is TreeEvent.OnZoomIn -> {
                 _state.update { it.copy(scale = (it.scale + event.delta).coerceAtMost(3f)) }
             }
@@ -55,13 +87,16 @@ class TreeViewModel(
                     val newScale = (oldScale * event.zoom).coerceIn(0.1f, 3f)
                     val actualZoom = newScale / oldScale
                     val newOffset = event.centroid + (it.offset - event.centroid) * actualZoom + event.pan
-                    it.copy(
-                        scale = newScale,
-                        offset = newOffset,
-                    )
+                    it.copy(scale = newScale, offset = newOffset)
                 }
             }
 
+            else -> {}
+        }
+    }
+
+    private fun handleSystemEvents(event: TreeEvent) {
+        when (event) {
             TreeEvent.OnNavigationConsumed -> {
                 _state.update { it.copy(shouldNavigateBack = false) }
             }
@@ -70,6 +105,12 @@ class TreeViewModel(
                 _state.update { it.copy(error = null) }
             }
 
+            else -> {}
+        }
+    }
+
+    private fun handleSelection(event: TreeEvent) {
+        when (event) {
             is TreeEvent.OnPersonSelected -> {
                 _state.update {
                     val currentSelected = it.selectedPersonIds
@@ -81,18 +122,39 @@ class TreeViewModel(
                         } else {
                             listOf(event.personId)
                         }
-                    it.copy(selectedPersonIds = newSelected)
+
+                    val relationshipId =
+                        if (newSelected.size == 2) {
+                            val id1 = newSelected.first()
+                            val id2 = newSelected.last()
+                            it.tree.relationships
+                                .find { rel ->
+                                    (rel.personId1 == id1 && rel.personId2 == id2) ||
+                                        (rel.personId1 == id2 && rel.personId2 == id1)
+                                }?.id
+                        } else {
+                            null
+                        }
+
+                    it.copy(
+                        selectedPersonIds = newSelected,
+                        selectedRelationshipId = relationshipId,
+                    )
                 }
             }
 
             TreeEvent.OnDismissSelection -> {
-                _state.update { it.copy(selectedPersonIds = emptyList()) }
+                _state.update {
+                    it.copy(selectedPersonIds = emptyList(), selectedRelationshipId = null)
+                }
             }
 
-            TreeEvent.OnAddRelationship -> {
-                // To be implemented in US-020
-            }
+            else -> {}
+        }
+    }
 
+    private fun handlePersonMovement(event: TreeEvent) {
+        when (event) {
             is TreeEvent.OnPersonMove -> {
                 _state.update { state ->
                     val updatedCentralPerson =
@@ -143,11 +205,7 @@ class TreeViewModel(
                                     }
 
                                 domainPerson?.let { person ->
-                                    val updatedPerson =
-                                        person.copy(
-                                            x = node.position.x,
-                                            y = node.position.y,
-                                        )
+                                    val updatedPerson = person.copy(x = node.position.x, y = node.position.y)
                                     updatePersonUseCase(treeId, updatedPerson)
                                 }
                             }
@@ -157,6 +215,8 @@ class TreeViewModel(
                     }
                 }
             }
+
+            else -> {}
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
@@ -264,8 +264,7 @@ class TreeViewModel(
         val parents =
             relationships
                 .filter {
-                    it.type == Relationship.RelationshipType.BIOLOGICAL_OFFSPRING &&
-                        it.personId2 == centralPersonId
+                    it.type.isDescendant && it.personId2 == centralPersonId
                 }.map { it.personId1 }
                 .toSet()
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
@@ -9,16 +9,22 @@ import dev.saragones3.genogramia.domain.model.Relationship
 import dev.saragones3.genogramia.domain.usecase.GetTreeUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdatePersonUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
+import dev.saragones3.genogramia.domain.util.DateProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.yearsUntil
+import kotlin.time.Instant
 
 class TreeViewModel(
     private val getTreeUseCase: GetTreeUseCase,
     private val updatePersonUseCase: UpdatePersonUseCase,
     private val dateFormatter: DateFormatter,
+    private val dateProvider: DateProvider,
 ) : ViewModel() {
     private val _state = MutableStateFlow(TreeState())
     val state: StateFlow<TreeState> = _state.asStateFlow()
@@ -317,14 +323,18 @@ class TreeViewModel(
         val birthYear = birthDate.let { dateFormatter.formatDate(it, "yyyy") }
         val deathYear = deathDate?.let { dateFormatter.formatDate(it, "yyyy") } ?: ""
 
-        val age =
-            if (birthYear.isNotEmpty()) {
-                val start = birthYear.toIntOrNull()
-                val end = deathYear.toIntOrNull() ?: 2024 // For simplicity, using 2024 as current year
-                if (start != null) (end - start).toString() else ""
-            } else {
-                ""
-            }
+        val birthLocalDate =
+            Instant
+                .fromEpochMilliseconds(birthDate)
+                .toLocalDateTime(TimeZone.UTC)
+                .date
+        val endLocalDate =
+            (deathDate ?: dateProvider.nowEpochMilliseconds())
+                .let { Instant.fromEpochMilliseconds(it) }
+                .toLocalDateTime(TimeZone.UTC)
+                .date
+
+        val age = birthLocalDate.yearsUntil(endLocalDate).toString()
 
         return PersonNodeUi(
             id = id,

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/AddPersonUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/AddPersonUseCaseTest.kt
@@ -2,7 +2,7 @@ package dev.saragones3.genogramia.domain.usecase
 
 import dev.saragones3.genogramia.domain.model.GenogramTree
 import dev.saragones3.genogramia.domain.model.Person
-import dev.saragones3.genogramia.domain.util.DateProvider
+import dev.saragones3.genogramia.fakes.FakeDateProvider
 import dev.saragones3.genogramia.fakes.FakeTreeRepository
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
@@ -13,8 +13,8 @@ import kotlin.test.assertTrue
 class AddPersonUseCaseTest {
     private lateinit var repository: FakeTreeRepository
     private val fakeDateProvider =
-        object : DateProvider {
-            override fun nowEpochMilliseconds(): Long = 1778716800000L
+        FakeDateProvider().apply {
+            currentTimeMillis = 1778716800000L
         }
     private lateinit var useCase: AddPersonUseCase
 

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/AddRelationshipUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/AddRelationshipUseCaseTest.kt
@@ -65,4 +65,25 @@ class AddRelationshipUseCaseTest {
             val updatedTree = repository.getTree("invalid-tree")
             assertEquals(null, updatedTree)
         }
+
+    @Test
+    fun `when relationship with same id exists it is updated instead of added as duplicate`() =
+        runTest {
+            val existingRel =
+                Relationship(
+                    id = "rel-1",
+                    personId1 = "p1",
+                    personId2 = "p2",
+                    type = Relationship.RelationshipType.MARRIAGE,
+                )
+            repository.createTree(tree.copy(relationships = listOf(existingRel)))
+
+            val updatedRel = existingRel.copy(type = Relationship.RelationshipType.DIVORCE)
+
+            useCase("tree-1", updatedRel)
+
+            val updatedTree = repository.getTree("tree-1")
+            assertEquals(1, updatedTree?.relationships?.size)
+            assertEquals(Relationship.RelationshipType.DIVORCE, updatedTree?.relationships?.get(0)?.type)
+        }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/NewTreeUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/NewTreeUseCaseTest.kt
@@ -2,7 +2,7 @@ package dev.saragones3.genogramia.domain.usecase
 
 import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.util.DateFormatter
-import dev.saragones3.genogramia.domain.util.DateProvider
+import dev.saragones3.genogramia.fakes.FakeDateProvider
 import dev.saragones3.genogramia.fakes.FakeTreeRepository
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
@@ -14,8 +14,8 @@ class NewTreeUseCaseTest {
     private lateinit var repository: FakeTreeRepository
     private val dateFormatter = DateFormatter()
     private val fakeDateProvider =
-        object : DateProvider {
-            override fun nowEpochMilliseconds(): Long = 1778716800000L // 14-may-2026
+        FakeDateProvider().apply {
+            currentTimeMillis = 1778716800000L // 14-may-2026
         }
     private lateinit var useCase: NewTreeUseCase
 

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeDateProvider.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeDateProvider.kt
@@ -1,0 +1,12 @@
+package dev.saragones3.genogramia.fakes
+
+import dev.saragones3.genogramia.domain.util.DateProvider
+import kotlin.time.Instant
+
+class FakeDateProvider : DateProvider {
+    var currentTimeMillis: Long = 0L
+
+    override fun nowEpochMilliseconds(): Long = currentTimeMillis
+
+    override fun now(): Instant = Instant.fromEpochMilliseconds(currentTimeMillis)
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModelTest.kt
@@ -7,7 +7,7 @@ import dev.saragones3.genogramia.domain.usecase.AddPersonUseCase
 import dev.saragones3.genogramia.domain.usecase.GetPersonUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdatePersonUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
-import dev.saragones3.genogramia.domain.util.DateProvider
+import dev.saragones3.genogramia.fakes.FakeDateProvider
 import dev.saragones3.genogramia.fakes.FakeTreeRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -27,8 +27,8 @@ class AddPersonViewModelTest {
     private val treeRepository = FakeTreeRepository()
 
     private val fakeDateProvider =
-        object : DateProvider {
-            override fun nowEpochMilliseconds(): Long = 1778716800000L
+        FakeDateProvider().apply {
+            currentTimeMillis = 1778716800000L
         }
 
     private val dateFormatter = DateFormatter()

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModelTest.kt
@@ -164,6 +164,50 @@ class AddRelationshipViewModelTest {
         }
 
     @Test
+    fun `when adoption relationship is detected hasConsanguinityRisk is false`() =
+        runTest {
+            val parent = Person(id = "p-parent", firstName = "Parent", lastName = "Root", birthDate = 0L)
+            val p1 = Person(id = "p1", firstName = "John", lastName = "Doe", birthDate = 0L)
+            val p2 = Person(id = "p2", firstName = "Jane", lastName = "Smith", birthDate = 0L)
+
+            // One biological, one adoption -> No consanguinity risk between p1 and p2
+            val relationship1 =
+                Relationship(
+                    id = "rel-1",
+                    personId1 = "p-parent",
+                    personId2 = "p1",
+                    type = Relationship.RelationshipType.BIOLOGICAL_OFFSPRING,
+                )
+            val relationship2 =
+                Relationship(
+                    id = "rel-2",
+                    personId1 = "p-parent",
+                    personId2 = "p2",
+                    type = Relationship.RelationshipType.ADOPTION_LEGAL,
+                )
+
+            val mixedTree =
+                GenogramTree(
+                    id = "tree-mixed",
+                    name = "Mixed Tree",
+                    ancestorCount = 3,
+                    lastUpdated = "2024-05-15",
+                    centralPerson = parent,
+                    persons = listOf(p1, p2),
+                    relationships = listOf(relationship1, relationship2),
+                )
+            repository.createTree(mixedTree)
+
+            viewModel.onResume("tree-mixed", "p1", "p2")
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertFalse(
+                viewModel.state.value.hasConsanguinityRisk,
+                "Should NOT have consanguinity risk when one sibling is adopted",
+            )
+        }
+
+    @Test
     fun `when bond type is selected state is updated`() =
         runTest {
             viewModel.onEvent(AddRelationshipEvent.OnBondTypeSelected(Relationship.RelationshipType.DIVORCE))

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModelTest.kt
@@ -8,7 +8,7 @@ import dev.saragones3.genogramia.domain.usecase.AddRelationshipUseCase
 import dev.saragones3.genogramia.domain.usecase.GetPersonUseCase
 import dev.saragones3.genogramia.domain.usecase.GetTreeUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
-import dev.saragones3.genogramia.domain.util.DateProvider
+import dev.saragones3.genogramia.fakes.FakeDateProvider
 import dev.saragones3.genogramia.fakes.FakeTreeRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -28,8 +28,8 @@ class AddRelationshipViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private val repository = FakeTreeRepository()
     private val fakeDateProvider =
-        object : DateProvider {
-            override fun nowEpochMilliseconds(): Long = 1000L
+        FakeDateProvider().apply {
+            currentTimeMillis = 1000L
         }
     private val dateFormatter = DateFormatter()
     private val getPersonUseCase = GetPersonUseCase(repository)

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModelTest.kt
@@ -238,4 +238,59 @@ class AddRelationshipViewModelTest {
             val savedRelationship = updatedTree?.relationships?.first()
             assertEquals(Relationship.EmotionalBond.ABUSE, savedRelationship?.emotionalBond)
         }
+
+    @Test
+    fun `when onResume is called with relationshipId data is prefilled`() =
+        runTest {
+            val relId = "rel-123"
+            val existingRel =
+                Relationship(
+                    id = relId,
+                    personId1 = "p1",
+                    personId2 = "p2",
+                    type = Relationship.RelationshipType.COHABITATION,
+                    emotionalBond = Relationship.EmotionalBond.CONFLICTUAL,
+                    effectiveDate = 123456789L,
+                )
+            val treeWithRel = tree.copy(relationships = listOf(existingRel))
+            repository.createTree(treeWithRel)
+
+            viewModel.onResume("tree-1", null, null, relId)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertEquals(relId, state.relationshipId)
+            assertEquals(Relationship.RelationshipType.COHABITATION, state.bondType)
+            assertEquals(Relationship.EmotionalBond.CONFLICTUAL, state.emotionalBond)
+            assertEquals(123456789L, state.effectiveDate)
+            assertEquals("p1", state.person1?.id)
+            assertEquals("p2", state.person2?.id)
+        }
+
+    @Test
+    fun `when saving an existing relationship it updates instead of adding new`() =
+        runTest {
+            val relId = "rel-123"
+            val existingRel =
+                Relationship(
+                    id = relId,
+                    personId1 = "p1",
+                    personId2 = "p2",
+                    type = Relationship.RelationshipType.MARRIAGE,
+                    emotionalBond = Relationship.EmotionalBond.POSITIVE,
+                )
+            repository.createTree(tree.copy(relationships = listOf(existingRel)))
+
+            viewModel.onResume("tree-1", null, null, relId)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.onEvent(AddRelationshipEvent.OnBondTypeSelected(Relationship.RelationshipType.DIVORCE))
+            viewModel.onEvent(AddRelationshipEvent.OnConfirmClick)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val updatedTree = repository.getTree("tree-1")
+            assertEquals(1, updatedTree?.relationships?.size)
+            assertEquals(Relationship.RelationshipType.DIVORCE, updatedTree?.relationships?.first()?.type)
+            assertEquals(relId, updatedTree?.relationships?.first()?.id)
+        }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModelTest.kt
@@ -293,4 +293,54 @@ class AddRelationshipViewModelTest {
             assertEquals(Relationship.RelationshipType.DIVORCE, updatedTree?.relationships?.first()?.type)
             assertEquals(relId, updatedTree?.relationships?.first()?.id)
         }
+
+    @Test
+    fun `when date is selected state is updated with formatted date`() =
+        runTest {
+            val date = 1715731200000L // May 15, 2024
+            val pattern = "MM/dd/yyyy"
+
+            viewModel.onEvent(AddRelationshipEvent.OnDateSelected(date, pattern))
+
+            val state = viewModel.state.value
+            assertEquals(date, state.effectiveDate)
+            assertEquals("05/15/2024", state.effectiveDateFormatted)
+        }
+
+    @Test
+    fun `when prefilling relationship effectiveDateFormatted is set`() =
+        runTest {
+            val date = 1715731200000L
+            val existingRel =
+                Relationship(
+                    id = "rel-1",
+                    personId1 = "p1",
+                    personId2 = "p2",
+                    type = Relationship.RelationshipType.MARRIAGE,
+                    effectiveDate = date,
+                )
+            repository.createTree(tree.copy(relationships = listOf(existingRel)))
+
+            viewModel.onResume("tree-1", null, null, "rel-1")
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals("05/15/2024", viewModel.state.value.effectiveDateFormatted)
+        }
+
+    @Test
+    fun `when back click event is received shouldNavigateBack is true`() =
+        runTest {
+            viewModel.onEvent(AddRelationshipEvent.OnBackClick)
+            assertTrue(viewModel.state.value.shouldNavigateBack)
+        }
+
+    @Test
+    fun `when navigation handled event is received shouldNavigateBack is false`() =
+        runTest {
+            viewModel.onEvent(AddRelationshipEvent.OnBackClick)
+            assertTrue(viewModel.state.value.shouldNavigateBack)
+
+            viewModel.onEvent(AddRelationshipEvent.OnNavigationHandled)
+            assertFalse(viewModel.state.value.shouldNavigateBack)
+        }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeViewModelTest.kt
@@ -6,8 +6,8 @@ import dev.saragones3.genogramia.domain.model.User
 import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
 import dev.saragones3.genogramia.domain.usecase.NewTreeUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
-import dev.saragones3.genogramia.domain.util.DateProvider
 import dev.saragones3.genogramia.fakes.FakeAuthRepository
+import dev.saragones3.genogramia.fakes.FakeDateProvider
 import dev.saragones3.genogramia.fakes.FakeTreeRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -26,10 +26,9 @@ class NewTreeViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private val treeRepository = FakeTreeRepository()
     private val authRepository = FakeAuthRepository()
-
     private val fakeDateProvider =
-        object : DateProvider {
-            override fun nowEpochMilliseconds(): Long = 1778716800000L // 14-may-2026
+        FakeDateProvider().apply {
+            currentTimeMillis = 1778716800000L // 14-may-2026
         }
 
     private val dateFormatter = DateFormatter()

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
@@ -8,6 +8,7 @@ import dev.saragones3.genogramia.domain.model.Relationship
 import dev.saragones3.genogramia.domain.usecase.GetTreeUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdatePersonUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
+import dev.saragones3.genogramia.fakes.FakeDateProvider
 import dev.saragones3.genogramia.fakes.FakeTreeRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -27,12 +28,13 @@ class TreeViewModelTest {
     private val getTreeUseCase = GetTreeUseCase(treeRepository)
     private val updatePersonUseCase = UpdatePersonUseCase(treeRepository)
     private val dateFormatter = DateFormatter()
+    private val dateProvider = FakeDateProvider()
     private lateinit var viewModel: TreeViewModel
 
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = TreeViewModel(getTreeUseCase, updatePersonUseCase, dateFormatter)
+        viewModel = TreeViewModel(getTreeUseCase, updatePersonUseCase, dateFormatter, dateProvider)
     }
 
     @AfterTest
@@ -117,6 +119,28 @@ class TreeViewModelTest {
             assertEquals("1989", centralPerson.deathDateText)
             assertEquals("74", centralPerson.age)
             assertEquals(true, centralPerson.isDeceased)
+        }
+
+    @Test
+    fun `when person is alive age is calculated based on current date`() =
+        runTest {
+            // Set current date to 2024
+            dateProvider.currentTimeMillis = 1704067200000L // 2024-01-01
+
+            // 1980-01-01
+            val person = Person("p1", "John", "Doe", birthDate = 315532800000L)
+            val tree = GenogramTree("t1", "Family", 1, "now", person)
+            treeRepository.createTree(tree)
+
+            viewModel.onEvent(TreeEvent.LoadTree("t1"))
+
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val centralPerson = viewModel.state.value.tree.centralPerson
+            assertEquals("1980", centralPerson.birthDateText)
+            assertEquals("", centralPerson.deathDateText)
+            assertEquals("44", centralPerson.age)
+            assertEquals(false, centralPerson.isDeceased)
         }
 
     @Test
@@ -320,5 +344,42 @@ class TreeViewModelTest {
             val savedTree = treeRepository.getTree("t1")
             assertEquals(100f, savedTree?.centralPerson?.x)
             assertEquals(200f, savedTree?.centralPerson?.y)
+        }
+
+    @Test
+    fun `age calculation handles birthday not yet reached in current year`() =
+        runTest {
+            // Current date: 2024-05-01
+            dateProvider.currentTimeMillis = 1714521600000L
+
+            // Birth date: 1980-06-01 (Birthday hasn't happened yet in 2024)
+            val person = Person("p1", "John", "Doe", birthDate = 328665600000L)
+            val tree = GenogramTree("t1", "Family", 1, "now", person)
+            treeRepository.createTree(tree)
+
+            viewModel.onEvent(TreeEvent.LoadTree("t1"))
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val centralPerson = viewModel.state.value.tree.centralPerson
+            // 2024 - 1980 = 44, but since it's May and birthday is June, should be 43
+            assertEquals("43", centralPerson.age)
+        }
+
+    @Test
+    fun `age calculation handles birthday already reached in current year`() =
+        runTest {
+            // Current date: 2024-07-01
+            dateProvider.currentTimeMillis = 1719792000000L
+
+            // Birth date: 1980-06-01 (Birthday already happened in 2024)
+            val person = Person("p1", "John", "Doe", birthDate = 328665600000L)
+            val tree = GenogramTree("t1", "Family", 1, "now", person)
+            treeRepository.createTree(tree)
+
+            viewModel.onEvent(TreeEvent.LoadTree("t1"))
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val centralPerson = viewModel.state.value.tree.centralPerson
+            assertEquals("44", centralPerson.age)
         }
 }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
@@ -1,5 +1,6 @@
 package dev.saragones3.genogramia.presentation.tree
 
+import androidx.compose.ui.geometry.Offset
 import app.cash.turbine.test
 import dev.saragones3.genogramia.domain.model.GenogramTree
 import dev.saragones3.genogramia.domain.model.Person
@@ -147,10 +148,8 @@ class TreeViewModelTest {
     @Test
     fun `when OnTransform event is received scale and offset are updated`() =
         runTest {
-            val centroid = androidx.compose.ui.geometry.Offset.Zero
-            val pan =
-                androidx.compose.ui.geometry
-                    .Offset(10f, 20f)
+            val centroid = Offset.Zero
+            val pan = Offset(10f, 20f)
             viewModel.onEvent(TreeEvent.OnTransform(centroid, pan, 1.1f))
 
             val state = viewModel.state.value
@@ -245,11 +244,44 @@ class TreeViewModelTest {
         }
 
     @Test
-    fun `when OnDismissSelection event is received selectedPersonIds is cleared`() =
+    fun `when two persons with existing relationship are selected, relationshipId is set automatically`() =
         runTest {
+            val central = Person("p1", "John", "Doe", 0L)
+            val p2 = Person("p2", "Jane", "Doe", 0L)
+            val rel =
+                Relationship(
+                    id = "r1",
+                    personId1 = "p1",
+                    personId2 = "p2",
+                    type = Relationship.RelationshipType.MARRIAGE,
+                )
+            val tree = GenogramTree("t1", "Family", 2, "now", central, listOf(p2), listOf(rel))
+            treeRepository.createTree(tree)
+
+            viewModel.onEvent(TreeEvent.LoadTree("t1"))
+            testDispatcher.scheduler.advanceUntilIdle()
+
             viewModel.onEvent(TreeEvent.OnPersonSelected("p1"))
-            viewModel.onEvent(TreeEvent.OnDismissSelection)
-            assertEquals(emptyList<String>(), viewModel.state.value.selectedPersonIds)
+            viewModel.onEvent(TreeEvent.OnPersonSelected("p2"))
+
+            assertEquals("r1", viewModel.state.value.selectedRelationshipId)
+        }
+
+    @Test
+    fun `when two persons without relationship are selected, relationshipId is null`() =
+        runTest {
+            val central = Person("p1", "John", "Doe", 0L)
+            val p2 = Person("p2", "Jane", "Doe", 0L)
+            val tree = GenogramTree("t1", "Family", 2, "now", central, listOf(p2))
+            treeRepository.createTree(tree)
+
+            viewModel.onEvent(TreeEvent.LoadTree("t1"))
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.onEvent(TreeEvent.OnPersonSelected("p1"))
+            viewModel.onEvent(TreeEvent.OnPersonSelected("p2"))
+
+            assertEquals(null, viewModel.state.value.selectedRelationshipId)
         }
 
     @Test
@@ -263,9 +295,7 @@ class TreeViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             val initialPos = viewModel.state.value.tree.centralPerson.position
-            val delta =
-                androidx.compose.ui.geometry
-                    .Offset(10f, 20f)
+            val delta = Offset(10f, 20f)
             viewModel.onEvent(TreeEvent.OnPersonMove("p1", delta))
 
             assertEquals(initialPos + delta, viewModel.state.value.tree.centralPerson.position)
@@ -281,9 +311,7 @@ class TreeViewModelTest {
             viewModel.onEvent(TreeEvent.LoadTree("t1"))
             testDispatcher.scheduler.advanceUntilIdle()
 
-            val delta =
-                androidx.compose.ui.geometry
-                    .Offset(100f, 200f)
+            val delta = Offset(100f, 200f)
             viewModel.onEvent(TreeEvent.OnPersonMove("p1", delta))
             viewModel.onEvent(TreeEvent.OnPersonMoveFinished("p1"))
 

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
@@ -382,4 +382,36 @@ class TreeViewModelTest {
             val centralPerson = viewModel.state.value.tree.centralPerson
             assertEquals("44", centralPerson.age)
         }
+
+    @Test
+    fun `when LoadTree has adoption relationship adoptive parent is positioned as parent`() =
+        runTest {
+            val central = Person("child", "Child", "Doe", 0L)
+            val adoptiveParent =
+                Person(
+                    id = "parent",
+                    firstName = "Adoptive",
+                    lastName = "Parent",
+                    birthDate = 0L,
+                    biologicalSex = Person.BiologicalSex.MALE,
+                )
+            val rel =
+                Relationship(
+                    id = "r1",
+                    personId1 = "parent",
+                    personId2 = "child",
+                    type = Relationship.RelationshipType.ADOPTION_LEGAL,
+                )
+            val tree = GenogramTree("t1", "Family", 2, "now", central, listOf(adoptiveParent), listOf(rel))
+            treeRepository.createTree(tree)
+
+            viewModel.onEvent(TreeEvent.LoadTree("t1"))
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val mappedParent =
+                viewModel.state.value.tree.persons
+                    .find { it.id == "parent" }
+            // Parents are positioned at y = -250f
+            assertEquals(-250f, mappedParent?.position?.y)
+        }
 }


### PR DESCRIPTION
## Descripción

Implementa el escenario US-021: el usuario puede tocar una línea de relación en el Canvas del Genograma en modo edición, lo que resalta la línea y muestra opciones para editar o eliminar la relación.

## Cambios realizados

- Detección de tap sobre líneas de relación en el Canvas del Genograma
- Resaltado visual de la línea seleccionada
- Aparición de opciones de edición/eliminación al seleccionar una relación

## Issue relacionado

Fixes #69

## Escenario Gherkin cubierto

```gherkin
Scenario: User taps on a relationship line
Given the user is on the Genogram Canvas in edit mode
    When the user taps on a connecting line between two nodes
    Then the line is highlighted and options to edit or delete appear
```
