### PR TITLE
[US-021] User deletes a relationship

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -191,4 +191,7 @@
     <string name="add_relationship_person">Persona</string>
     <string name="add_relationship_swap_roles">Intercambiar Roles</string>
     <string name="add_relationship_select_date">Seleccionar fecha</string>
+    <string name="delete_relationship">Eliminar relación</string>
+    <string name="delete_relationship_confirmation_title">Eliminar Relación</string>
+    <string name="delete_relationship_confirmation_message">¿Estás seguro de que quieres eliminar esta relación? Esta acción no se puede deshacer.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -191,4 +191,7 @@
     <string name="add_relationship_person">Person</string>
     <string name="add_relationship_swap_roles">Swap Roles</string>
     <string name="add_relationship_select_date">Select date</string>
+    <string name="delete_relationship">Delete relationship</string>
+    <string name="delete_relationship_confirmation_title">Delete Relationship</string>
+    <string name="delete_relationship_confirmation_message">Are you sure you want to delete this relationship? This action cannot be undone.</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
@@ -11,6 +11,7 @@ import dev.saragones3.genogramia.domain.usecase.AddPersonUseCase
 import dev.saragones3.genogramia.domain.usecase.AddRelationshipUseCase
 import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
 import dev.saragones3.genogramia.domain.usecase.DeleteAccountUseCase
+import dev.saragones3.genogramia.domain.usecase.DeleteRelationshipUseCase
 import dev.saragones3.genogramia.domain.usecase.GetPersonUseCase
 import dev.saragones3.genogramia.domain.usecase.GetTreeUseCase
 import dev.saragones3.genogramia.domain.usecase.GetTreesUseCase
@@ -21,6 +22,7 @@ import dev.saragones3.genogramia.domain.usecase.SignOutUseCase
 import dev.saragones3.genogramia.domain.usecase.SignUpUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdatePasswordUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdatePersonUseCase
+import dev.saragones3.genogramia.domain.usecase.UpdateTreeUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
 import dev.saragones3.genogramia.domain.util.DateProvider
 import dev.saragones3.genogramia.presentation.addperson.AddPersonViewModel
@@ -86,7 +88,9 @@ private val domainModule =
         factoryOf(::NewTreeUseCase)
         factoryOf(::AddPersonUseCase)
         factoryOf(::AddRelationshipUseCase)
+        factoryOf(::DeleteRelationshipUseCase)
         factoryOf(::UpdatePersonUseCase)
+        factoryOf(::UpdateTreeUseCase)
         factoryOf(::GetPersonUseCase)
         factoryOf(::GetTreesUseCase)
         factoryOf(::GetTreeUseCase)

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/DeleteRelationshipUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/DeleteRelationshipUseCase.kt
@@ -1,0 +1,16 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.repository.TreeRepository
+
+class DeleteRelationshipUseCase(
+    private val repository: TreeRepository,
+) {
+    suspend operator fun invoke(
+        treeId: String,
+        relationshipId: String,
+    ) {
+        val tree = repository.getTree(treeId) ?: return
+        val updatedRelationships = tree.relationships.filter { it.id != relationshipId }
+        repository.updateTree(tree.copy(relationships = updatedRelationships))
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/UpdateTreeUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/UpdateTreeUseCase.kt
@@ -1,0 +1,12 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.GenogramTree
+import dev.saragones3.genogramia.domain.repository.TreeRepository
+
+class UpdateTreeUseCase(
+    private val repository: TreeRepository,
+) {
+    suspend operator fun invoke(tree: GenogramTree) {
+        repository.updateTree(tree)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipEvent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipEvent.kt
@@ -18,6 +18,8 @@ sealed interface AddRelationshipEvent {
 
     data object OnConfirmClick : AddRelationshipEvent
 
+    data object OnDeleteClick : AddRelationshipEvent
+
     data object OnSwapPersons : AddRelationshipEvent
 
     data object OnBackClick : AddRelationshipEvent

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipScreen.kt
@@ -23,8 +23,10 @@ import androidx.compose.material.icons.filled.AutoGraph
 import androidx.compose.material.icons.filled.BrokenImage
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ConnectWithoutContact
 import androidx.compose.material.icons.filled.ContentCut
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.FamilyRestroom
@@ -41,6 +43,7 @@ import androidx.compose.material.icons.filled.SentimentSatisfied
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material.icons.filled.VolunteerActivism
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -54,6 +57,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -113,7 +117,12 @@ import genogramia.composeapp.generated.resources.add_relationship_separation
 import genogramia.composeapp.generated.resources.add_relationship_swap_roles
 import genogramia.composeapp.generated.resources.add_relationship_title
 import genogramia.composeapp.generated.resources.date_format
+import genogramia.composeapp.generated.resources.delete_relationship
+import genogramia.composeapp.generated.resources.delete_relationship_confirmation_message
+import genogramia.composeapp.generated.resources.delete_relationship_confirmation_title
 import genogramia.composeapp.generated.resources.edit_relationship
+import genogramia.composeapp.generated.resources.settings_cancel
+import genogramia.composeapp.generated.resources.settings_confirm
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -154,6 +163,7 @@ private fun AddRelationshipContent(
     onBackClick: () -> Unit,
 ) {
     var showDatePicker by remember { mutableStateOf(false) }
+    var showDeleteConfirmation by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -262,6 +272,33 @@ private fun AddRelationshipContent(
                     Spacer(modifier = Modifier.height(24.dp))
                     MedicalConflictBanner()
                 }
+
+                if (state.relationshipId != null) {
+                    Spacer(modifier = Modifier.height(32.dp))
+                    Button(
+                        onClick = { showDeleteConfirmation = true },
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 24.dp)
+                                .height(56.dp),
+                        shape = RoundedCornerShape(28.dp),
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor = Color(0xFFF1F3F4),
+                                contentColor = Color(0xFFB3261E),
+                            ),
+                        enabled = !state.isSaving,
+                    ) {
+                        Icon(imageVector = Icons.Default.Delete, contentDescription = null)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = stringResource(Res.string.delete_relationship).uppercase(),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
+                }
                 Spacer(modifier = Modifier.height(24.dp))
             }
         }
@@ -275,6 +312,33 @@ private fun AddRelationshipContent(
                     showDatePicker = false
                 },
                 onDismiss = { showDatePicker = false },
+            )
+        }
+
+        if (showDeleteConfirmation) {
+            AlertDialog(
+                onDismissRequest = { showDeleteConfirmation = false },
+                title = { Text(stringResource(Res.string.delete_relationship_confirmation_title)) },
+                text = { Text(stringResource(Res.string.delete_relationship_confirmation_message)) },
+                confirmButton = {
+                    Button(
+                        onClick = {
+                            onEvent(AddRelationshipEvent.OnDeleteClick)
+                            showDeleteConfirmation = false
+                        },
+                        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFB3261E)),
+                    ) {
+                        Text(stringResource(Res.string.settings_confirm))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showDeleteConfirmation = false }) {
+                        Text(
+                            text = stringResource(Res.string.settings_cancel),
+                            color = Primary,
+                        )
+                    }
+                },
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.model.Relationship
 import dev.saragones3.genogramia.domain.usecase.AddRelationshipUseCase
+import dev.saragones3.genogramia.domain.usecase.DeleteRelationshipUseCase
 import dev.saragones3.genogramia.domain.usecase.GetPersonUseCase
 import dev.saragones3.genogramia.domain.usecase.GetTreeUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
@@ -19,6 +20,7 @@ class AddRelationshipViewModel(
     private val getPersonUseCase: GetPersonUseCase,
     private val getTreeUseCase: GetTreeUseCase,
     private val addRelationshipUseCase: AddRelationshipUseCase,
+    private val deleteRelationshipUseCase: DeleteRelationshipUseCase,
     private val dateProvider: DateProvider,
     private val dateFormatter: DateFormatter,
 ) : ViewModel() {
@@ -136,6 +138,10 @@ class AddRelationshipViewModel(
                 saveRelationship()
             }
 
+            AddRelationshipEvent.OnDeleteClick -> {
+                deleteRelationship()
+            }
+
             AddRelationshipEvent.OnSwapPersons -> {
                 _state.update {
                     it.copy(
@@ -173,6 +179,21 @@ class AddRelationshipViewModel(
                         effectiveDate = currentState.effectiveDate,
                     )
                 addRelationshipUseCase(treeId, relationship)
+                _state.update { it.copy(isSaving = false, shouldNavigateBack = true) }
+            } catch (e: Exception) {
+                _state.update { it.copy(isSaving = false, error = e.message) }
+            }
+        }
+    }
+
+    private fun deleteRelationship() {
+        val currentState = _state.value
+        val relationshipId = currentState.relationshipId ?: return
+
+        _state.update { it.copy(isSaving = true) }
+        viewModelScope.launch {
+            try {
+                deleteRelationshipUseCase(treeId, relationshipId)
                 _state.update { it.copy(isSaving = false, shouldNavigateBack = true) }
             } catch (e: Exception) {
                 _state.update { it.copy(isSaving = false, error = e.message) }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeEvent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeEvent.kt
@@ -49,4 +49,8 @@ sealed interface TreeEvent {
     data class OnPersonMoveFinished(
         val personId: String,
     ) : TreeEvent
+
+    data class OnViewportResetPerformed(
+        val treeId: String,
+    ) : TreeEvent
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
@@ -205,11 +205,10 @@ private fun TreeContent(
             }
 
             // Initial centering when tree is loaded
-            var lastLoadedTreeId by remember { mutableStateOf("") }
             LaunchedEffect(state.tree.id) {
-                if (state.tree.id.isNotEmpty() && state.tree.id != lastLoadedTreeId) {
+                if (state.tree.id.isNotEmpty() && state.tree.id != state.lastLoadedTreeId) {
                     resetViewport()
-                    lastLoadedTreeId = state.tree.id
+                    onEvent(TreeEvent.OnViewportResetPerformed(state.tree.id))
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeState.kt
@@ -11,6 +11,7 @@ data class TreeState(
     val shouldNavigateBack: Boolean = false,
     val selectedPersonIds: List<String> = emptyList(),
     val selectedRelationshipId: String? = null,
+    val lastLoadedTreeId: String = "",
 )
 
 enum class TreeError {

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
@@ -8,6 +8,7 @@ import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.model.Relationship
 import dev.saragones3.genogramia.domain.usecase.GetTreeUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdatePersonUseCase
+import dev.saragones3.genogramia.domain.usecase.UpdateTreeUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
 import dev.saragones3.genogramia.domain.util.DateProvider
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +24,7 @@ import kotlin.time.Instant
 class TreeViewModel(
     private val getTreeUseCase: GetTreeUseCase,
     private val updatePersonUseCase: UpdatePersonUseCase,
+    private val updateTreeUseCase: UpdateTreeUseCase,
     private val dateFormatter: DateFormatter,
     private val dateProvider: DateProvider,
 ) : ViewModel() {
@@ -61,6 +63,10 @@ class TreeViewModel(
             is TreeEvent.OnPersonMoveFinished,
             -> {
                 handlePersonMovement(event)
+            }
+
+            is TreeEvent.OnViewportResetPerformed -> {
+                _state.update { it.copy(lastLoadedTreeId = event.treeId) }
             }
         }
     }
@@ -227,12 +233,27 @@ class TreeViewModel(
     }
 
     private fun loadTree(id: String) {
-        _state.update { it.copy(isLoading = true, error = null) }
+        val isSameTree = _state.value.tree.id == id
+        _state.update {
+            it.copy(
+                isLoading = !isSameTree,
+                error = null,
+                selectedPersonIds = emptyList(),
+                selectedRelationshipId = null,
+            )
+        }
         viewModelScope.launch {
             try {
                 val tree = getTreeUseCase(id)
                 if (tree != null) {
-                    _state.update { it.copy(tree = tree.toUi(), isLoading = false) }
+                    val uiTree = tree.toUi()
+                    _state.update {
+                        it.copy(
+                            tree = uiTree,
+                            isLoading = false,
+                        )
+                    }
+                    bakeDefaultPositions(tree, uiTree)
                 } else {
                     _state.update {
                         it.copy(
@@ -249,6 +270,47 @@ class TreeViewModel(
                         error = TreeError.UNKNOWN,
                         shouldNavigateBack = true,
                     )
+                }
+            }
+        }
+    }
+
+    private fun bakeDefaultPositions(
+        domainTree: GenogramTree,
+        uiTree: TreeUi,
+    ) {
+        var needsUpdate = false
+        var updatedCentralPerson = domainTree.centralPerson
+        val updatedPersons = domainTree.persons.toMutableList()
+
+        if (domainTree.centralPerson.x == 0f && domainTree.centralPerson.y == 0f) {
+            val uiPos = uiTree.centralPerson.position
+            if (uiPos.x != 0f || uiPos.y != 0f) {
+                updatedCentralPerson = domainTree.centralPerson.copy(x = uiPos.x, y = uiPos.y)
+                needsUpdate = true
+            }
+        }
+
+        domainTree.persons.forEachIndexed { index, domainPerson ->
+            if (domainPerson.x == 0f && domainPerson.y == 0f) {
+                val uiPerson = uiTree.persons.find { it.id == domainPerson.id }
+                if (uiPerson != null && (uiPerson.position.x != 0f || uiPerson.position.y != 0f)) {
+                    updatedPersons[index] = domainPerson.copy(x = uiPerson.position.x, y = uiPerson.position.y)
+                    needsUpdate = true
+                }
+            }
+        }
+
+        if (needsUpdate) {
+            viewModelScope.launch {
+                try {
+                    updateTreeUseCase(
+                        domainTree.copy(
+                            centralPerson = updatedCentralPerson,
+                            persons = updatedPersons,
+                        ),
+                    )
+                } catch (_: Exception) {
                 }
             }
         }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/DeleteRelationshipUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/DeleteRelationshipUseCaseTest.kt
@@ -1,0 +1,73 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.GenogramTree
+import dev.saragones3.genogramia.domain.model.Person
+import dev.saragones3.genogramia.domain.model.Relationship
+import dev.saragones3.genogramia.fakes.FakeTreeRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DeleteRelationshipUseCaseTest {
+    private val repository = FakeTreeRepository()
+    private lateinit var useCase: DeleteRelationshipUseCase
+
+    private val person1 = Person(id = "p1", firstName = "John", lastName = "Doe", birthDate = 0L)
+    private val person2 = Person(id = "p2", firstName = "Jane", lastName = "Smith", birthDate = 0L)
+    private val relationship =
+        Relationship(
+            id = "rel-1",
+            personId1 = "p1",
+            personId2 = "p2",
+            type = Relationship.RelationshipType.MARRIAGE,
+        )
+    private val tree =
+        GenogramTree(
+            id = "tree-1",
+            name = "Test Tree",
+            ancestorCount = 2,
+            lastUpdated = "2024-05-15",
+            centralPerson = person1,
+            persons = listOf(person2),
+            relationships = listOf(relationship),
+        )
+
+    @BeforeTest
+    fun setup() {
+        useCase = DeleteRelationshipUseCase(repository)
+    }
+
+    @Test
+    fun `invoke should remove the relationship from the tree`() =
+        runTest {
+            repository.createTree(tree)
+
+            useCase(treeId = "tree-1", relationshipId = "rel-1")
+
+            val updatedTree = repository.getTree("tree-1")
+            assertTrue(updatedTree?.relationships?.isEmpty() ?: false)
+        }
+
+    @Test
+    fun `invoke should not fail if tree does not exist`() =
+        runTest {
+            useCase(treeId = "invalid", relationshipId = "rel-1")
+            // Should not throw exception
+        }
+
+    @Test
+    fun `invoke should not change other relationships`() =
+        runTest {
+            val rel2 = relationship.copy(id = "rel-2")
+            val treeWithTwoRels = tree.copy(relationships = listOf(relationship, rel2))
+            repository.createTree(treeWithTwoRels)
+
+            useCase(treeId = "tree-1", relationshipId = "rel-1")
+
+            val updatedTree = repository.getTree("tree-1")
+            assertEquals(1, updatedTree?.relationships?.size)
+            assertEquals("rel-2", updatedTree?.relationships?.first()?.id)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/UpdateTreeUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/UpdateTreeUseCaseTest.kt
@@ -1,0 +1,41 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.GenogramTree
+import dev.saragones3.genogramia.domain.model.Person
+import dev.saragones3.genogramia.fakes.FakeTreeRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UpdateTreeUseCaseTest {
+    private val repository = FakeTreeRepository()
+    private lateinit var useCase: UpdateTreeUseCase
+
+    private val person1 = Person(id = "p1", firstName = "John", lastName = "Doe", birthDate = 0L)
+    private val tree =
+        GenogramTree(
+            id = "tree-1",
+            name = "Test Tree",
+            ancestorCount = 1,
+            lastUpdated = "2024-05-15",
+            centralPerson = person1,
+        )
+
+    @BeforeTest
+    fun setup() {
+        useCase = UpdateTreeUseCase(repository)
+    }
+
+    @Test
+    fun `invoke should update the tree in repository`() =
+        runTest {
+            repository.createTree(tree)
+
+            val updatedTree = tree.copy(name = "Updated Name")
+            useCase(updatedTree)
+
+            val savedTree = repository.getTree("tree-1")
+            assertEquals("Updated Name", savedTree?.name)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addrelationship/AddRelationshipViewModelTest.kt
@@ -5,6 +5,7 @@ import dev.saragones3.genogramia.domain.model.GenogramTree
 import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.model.Relationship
 import dev.saragones3.genogramia.domain.usecase.AddRelationshipUseCase
+import dev.saragones3.genogramia.domain.usecase.DeleteRelationshipUseCase
 import dev.saragones3.genogramia.domain.usecase.GetPersonUseCase
 import dev.saragones3.genogramia.domain.usecase.GetTreeUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
@@ -35,6 +36,7 @@ class AddRelationshipViewModelTest {
     private val getPersonUseCase = GetPersonUseCase(repository)
     private val getTreeUseCase = GetTreeUseCase(repository)
     private val addRelationshipUseCase = AddRelationshipUseCase(repository)
+    private val deleteRelationshipUseCase = DeleteRelationshipUseCase(repository)
     private lateinit var viewModel: AddRelationshipViewModel
 
     private val person1 = Person(id = "p1", firstName = "John", lastName = "Doe", birthDate = 0L)
@@ -57,6 +59,7 @@ class AddRelationshipViewModelTest {
                 getPersonUseCase,
                 getTreeUseCase,
                 addRelationshipUseCase,
+                deleteRelationshipUseCase,
                 fakeDateProvider,
                 dateFormatter,
             )
@@ -376,6 +379,51 @@ class AddRelationshipViewModelTest {
         runTest {
             viewModel.onEvent(AddRelationshipEvent.OnBackClick)
             assertTrue(viewModel.state.value.shouldNavigateBack)
+        }
+
+    @Test
+    fun `when delete click is triggered relationship is deleted`() =
+        runTest {
+            val relId = "rel-123"
+            val existingRel =
+                Relationship(
+                    id = relId,
+                    personId1 = "p1",
+                    personId2 = "p2",
+                    type = Relationship.RelationshipType.MARRIAGE,
+                )
+            repository.createTree(tree.copy(relationships = listOf(existingRel)))
+
+            viewModel.onResume("tree-1", null, null, relId)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.onEvent(AddRelationshipEvent.OnDeleteClick)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val updatedTree = repository.getTree("tree-1")
+            assertTrue(updatedTree?.relationships?.isEmpty() ?: false)
+            assertTrue(viewModel.state.value.shouldNavigateBack)
+        }
+
+    @Test
+    fun `when delete fails state is updated with error`() =
+        runTest {
+            val relId = "rel-123"
+            repository.createTree(
+                tree.copy(
+                    relationships = listOf(Relationship(relId, "p1", "p2", Relationship.RelationshipType.MARRIAGE)),
+                ),
+            )
+            repository.shouldReturnError = true
+
+            viewModel.onResume("tree-1", null, null, relId)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.onEvent(AddRelationshipEvent.OnDeleteClick)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertFalse(viewModel.state.value.isSaving)
+            assertEquals("Fake tree repository error", viewModel.state.value.error)
         }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
@@ -7,6 +7,7 @@ import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.model.Relationship
 import dev.saragones3.genogramia.domain.usecase.GetTreeUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdatePersonUseCase
+import dev.saragones3.genogramia.domain.usecase.UpdateTreeUseCase
 import dev.saragones3.genogramia.domain.util.DateFormatter
 import dev.saragones3.genogramia.fakes.FakeDateProvider
 import dev.saragones3.genogramia.fakes.FakeTreeRepository
@@ -27,6 +28,7 @@ class TreeViewModelTest {
     private val treeRepository = FakeTreeRepository()
     private val getTreeUseCase = GetTreeUseCase(treeRepository)
     private val updatePersonUseCase = UpdatePersonUseCase(treeRepository)
+    private val updateTreeUseCase = UpdateTreeUseCase(treeRepository)
     private val dateFormatter = DateFormatter()
     private val dateProvider = FakeDateProvider()
     private lateinit var viewModel: TreeViewModel
@@ -34,7 +36,7 @@ class TreeViewModelTest {
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = TreeViewModel(getTreeUseCase, updatePersonUseCase, dateFormatter, dateProvider)
+        viewModel = TreeViewModel(getTreeUseCase, updatePersonUseCase, updateTreeUseCase, dateFormatter, dateProvider)
     }
 
     @AfterTest
@@ -413,5 +415,50 @@ class TreeViewModelTest {
                     .find { it.id == "parent" }
             // Parents are positioned at y = -250f
             assertEquals(-250f, mappedParent?.position?.y)
+        }
+
+    @Test
+    fun `when LoadTree has persons with 0,0 position, they are baked into repository`() =
+        runTest {
+            val central = Person("p1", "John", "Doe", 0L)
+            val p2 = Person("p2", "Partner", "Doe", 0L, biologicalSex = Person.BiologicalSex.FEMALE)
+            val rel =
+                Relationship(
+                    id = "r1",
+                    personId1 = "p1",
+                    personId2 = "p2",
+                    type = Relationship.RelationshipType.MARRIAGE,
+                )
+            // Both persons have 0,0 coordinates
+            val tree = GenogramTree("t1", "Family", 2, "now", central, listOf(p2), listOf(rel))
+            treeRepository.createTree(tree)
+
+            viewModel.onEvent(TreeEvent.LoadTree("t1"))
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val savedTree = treeRepository.getTree("t1")
+            // Partner should have been baked at Offset(250f, 0f) according to toUi() logic
+            assertEquals(250f, savedTree?.persons?.find { it.id == "p2" }?.x)
+            assertEquals(0f, savedTree?.persons?.find { it.id == "p2" }?.y)
+        }
+
+    @Test
+    fun `when relationship is removed baked positions are preserved`() =
+        runTest {
+            val central = Person("p1", "John", "Doe", 0L, x = 100f, y = 100f)
+            val p2 = Person("p2", "Ex-Partner", "Doe", 0L, x = 350f, y = 100f)
+            // No relationships
+            val tree = GenogramTree("t1", "Family", 2, "now", central, listOf(p2), emptyList())
+            treeRepository.createTree(tree)
+
+            viewModel.onEvent(TreeEvent.LoadTree("t1"))
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val uiP2 =
+                viewModel.state.value.tree.persons
+                    .find { it.id == "p2" }
+            // Should still be at 350, 100 even without the relationship that originally placed it there
+            assertEquals(350f, uiP2?.position?.x)
+            assertEquals(100f, uiP2?.position?.y)
         }
 }


### PR DESCRIPTION
## Descripción

Implementa el escenario US-021: el usuario puede eliminar una relación existente en el Canvas del Genograma. Al seleccionar una línea de relación y elegir la opción de eliminar, se muestra un diálogo de confirmación. Si el usuario confirma, la línea es eliminada del canvas y la relación se borra de Firestore (modo autenticado) o de memoria (modo invitado).

## Cambios realizados

- Diálogo de confirmación antes de eliminar una relación
- Eliminación de la línea del canvas tras confirmación
- Borrado de la relación en Firestore (modo autenticado) o en memoria (modo invitado)

## Issue relacionado

Fixes #71

## Escenario Gherkin cubierto

```gherkin
Scenario: User deletes a relationship
Given a relationship line is selected
    When the user chooses to delete it
    Then a confirmation dialog is shown
    When the user confirms
    Then the line is removed from the canvas
    And the relationship is deleted from Firestore (authenticated) or from memory (guest)
```
