### PR TITLE
feat(canvas): redibujar las líneas de relación entre nodos

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/legends/LegendsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/legends/LegendsScreen.kt
@@ -36,11 +36,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import dev.saragones3.genogramia.presentation.util.drawArrowHead
+import dev.saragones3.genogramia.domain.model.Relationship
 import dev.saragones3.genogramia.presentation.util.drawDeathMark
+import dev.saragones3.genogramia.presentation.util.drawEmotionalBondLine
 import dev.saragones3.genogramia.presentation.util.drawSexualOrientationMark
-import dev.saragones3.genogramia.presentation.util.drawSlashes
-import dev.saragones3.genogramia.presentation.util.drawZigzag
+import dev.saragones3.genogramia.presentation.util.drawStructuralRelationshipLine
 import dev.saragones3.genogramia.presentation.util.femaleNode
 import dev.saragones3.genogramia.presentation.util.maleNode
 import dev.saragones3.genogramia.ui.theme.GenogramiaTheme
@@ -364,8 +364,14 @@ private fun MarriageItem() {
     RelationshipItem(
         title = stringResource(Res.string.relationship_marriage),
         subtitle = stringResource(Res.string.legends_rel_marriage_desc),
-    ) { start, end ->
-        drawLineHelper(startX = start, endX = end)
+    ) { p1, p2, nodeSize ->
+        drawStructuralRelationshipLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            type = Relationship.RelationshipType.MARRIAGE,
+            color = Color.Gray,
+        )
     }
 }
 
@@ -374,11 +380,13 @@ private fun CohabitationItem() {
     RelationshipItem(
         title = stringResource(Res.string.relationship_cohabitation),
         subtitle = stringResource(Res.string.legends_rel_cohabitation_desc),
-    ) { start, end ->
-        drawLineHelper(
-            startX = start,
-            endX = end,
-            isDotted = true,
+    ) { p1, p2, nodeSize ->
+        drawStructuralRelationshipLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            type = Relationship.RelationshipType.COHABITATION,
+            color = Color.Gray,
         )
     }
 }
@@ -388,16 +396,13 @@ private fun SeparationItem() {
     RelationshipItem(
         title = stringResource(Res.string.relationship_separation),
         subtitle = stringResource(Res.string.legends_rel_separation_desc),
-    ) { start, end ->
-        drawLineHelper(
-            startX = start,
-            endX = end,
-            isDashed = true,
-        )
-        drawSlashes(
-            center = Offset(x = (start + end) / 2, y = size.height / 2),
-            count = 1,
-            direction = Offset(1f, 0f),
+    ) { p1, p2, nodeSize ->
+        drawStructuralRelationshipLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            type = Relationship.RelationshipType.SEPARATION,
+            color = Color.Gray,
         )
     }
 }
@@ -407,12 +412,13 @@ private fun DivorceItem() {
     RelationshipItem(
         title = stringResource(Res.string.relationship_divorce),
         subtitle = stringResource(Res.string.legends_rel_divorce_desc),
-    ) { start, end ->
-        drawLineHelper(startX = start, endX = end)
-        drawSlashes(
-            center = Offset(x = (start + end) / 2, y = size.height / 2),
-            count = 2,
-            direction = Offset(1f, 0f),
+    ) { p1, p2, nodeSize ->
+        drawStructuralRelationshipLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            type = Relationship.RelationshipType.DIVORCE,
+            color = Color.Gray,
         )
     }
 }
@@ -422,13 +428,13 @@ private fun ReconciliationItem() {
     RelationshipItem(
         title = stringResource(Res.string.relationship_reconciliation),
         subtitle = stringResource(Res.string.legends_rel_reconciliation_desc),
-    ) { start, end ->
-        drawLineHelper(startX = start, endX = end)
-        drawSlashes(
-            center = Offset((start + end) / 2, size.height / 2),
-            count = 2,
-            direction = Offset(1f, 0f),
-            isReconciliation = true,
+    ) { p1, p2, nodeSize ->
+        drawStructuralRelationshipLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            type = Relationship.RelationshipType.RECONCILIATION,
+            color = Color.Gray,
         )
     }
 }
@@ -530,7 +536,7 @@ private fun IdenticalTwinsItem() {
 private fun RelationshipItem(
     title: String,
     subtitle: String,
-    drawAction: DrawScope.(Float, Float) -> Unit,
+    drawAction: DrawScope.(Offset, Offset, Float) -> Unit,
 ) {
     Card(
         colors = CardDefaults.cardColors(containerColor = Color.White),
@@ -542,25 +548,27 @@ private fun RelationshipItem(
             modifier = Modifier.padding(16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Canvas(modifier = Modifier.width(100.dp).height(24.dp)) {
+            Canvas(modifier = Modifier.width(100.dp).height(64.dp)) {
                 val nodeSize = 16.dp.toPx()
                 val strokeWidth = 1.5.dp.toPx()
-                val squareX = 0f
-                val circleX = size.width - nodeSize
+                // Shift everything up a bit to make room for the bracket
+                val centerY = size.height / 2 - 8.dp.toPx()
+                val squareCenter = Offset(nodeSize / 2, centerY)
+                val circleCenter = Offset(size.width - nodeSize / 2, centerY)
 
                 drawRect(
                     color = Color(0xFF136299),
-                    topLeft = Offset(squareX, (size.height - nodeSize) / 2),
+                    topLeft = Offset(squareCenter.x - nodeSize / 2, squareCenter.y - nodeSize / 2),
                     size = Size(nodeSize, nodeSize),
                     style = Stroke(width = strokeWidth),
                 )
                 drawCircle(
                     color = Color(0xFF884364),
-                    center = Offset(circleX + nodeSize / 2, size.height / 2),
+                    center = circleCenter,
                     radius = nodeSize / 2,
                     style = Stroke(width = strokeWidth),
                 )
-                drawAction(nodeSize, circleX)
+                drawAction(squareCenter, circleCenter, nodeSize)
             }
             Spacer(modifier = Modifier.width(16.dp))
             Column {
@@ -677,235 +685,142 @@ private fun EmotionalBondsSection() {
 
 @Composable
 private fun PositiveItem() {
-    EmotionalBondItem(stringResource(Res.string.emotional_bond_positive)) {
-        drawLine(
+    EmotionalBondItem(stringResource(Res.string.emotional_bond_positive)) { p1, p2, nodeSize ->
+        drawEmotionalBondLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            bond = Relationship.EmotionalBond.POSITIVE,
             color = Color.White,
-            start = Offset(0f, size.height / 2),
-            end = Offset(size.width, size.height / 2),
-            strokeWidth = 2.dp.toPx(),
         )
     }
 }
 
 @Composable
 private fun DistantItem() {
-    EmotionalBondItem(stringResource(Res.string.emotional_bond_distant)) {
-        drawLine(
+    EmotionalBondItem(stringResource(Res.string.emotional_bond_distant)) { p1, p2, nodeSize ->
+        drawEmotionalBondLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            bond = Relationship.EmotionalBond.DISTANT,
             color = Color.White,
-            start = Offset(0f, size.height / 2),
-            end = Offset(size.width, size.height / 2),
-            strokeWidth = 2.dp.toPx(),
-            pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f),
         )
     }
 }
 
 @Composable
 private fun IntimateItem() {
-    EmotionalBondItem(stringResource(Res.string.emotional_bond_intimate)) {
-        val y = size.height / 2
-        drawLine(
+    EmotionalBondItem(stringResource(Res.string.emotional_bond_intimate)) { p1, p2, nodeSize ->
+        drawEmotionalBondLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            bond = Relationship.EmotionalBond.INTIMATE,
             color = Color.White,
-            start = Offset(0f, y - 2.dp.toPx()),
-            end = Offset(size.width, y - 2.dp.toPx()),
-            strokeWidth = 2.dp.toPx(),
-        )
-        drawLine(
-            color = Color.White,
-            start = Offset(0f, y + 2.dp.toPx()),
-            end = Offset(size.width, y + 2.dp.toPx()),
-            strokeWidth = 2.dp.toPx(),
         )
     }
 }
 
 @Composable
 private fun IntimateConflictualItem() {
-    EmotionalBondItem(stringResource(Res.string.emotional_bond_intimate_conflictual)) {
-        val y = size.height / 2
-        drawLine(
+    EmotionalBondItem(stringResource(Res.string.emotional_bond_intimate_conflictual)) { p1, p2, nodeSize ->
+        drawEmotionalBondLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            bond = Relationship.EmotionalBond.INTIMATE_CONFLICTUAL,
             color = Color.White,
-            start = Offset(0f, y - 4.dp.toPx()),
-            end = Offset(size.width, y - 4.dp.toPx()),
-            strokeWidth = 2.dp.toPx(),
-        )
-        drawLine(
-            color = Color.White,
-            start = Offset(0f, y + 4.dp.toPx()),
-            end = Offset(size.width, y + 4.dp.toPx()),
-            strokeWidth = 2.dp.toPx(),
-        )
-        drawZigzag(
-            start = Offset(0f, y),
-            end = Offset(size.width, y),
-            color = Color.White,
-            lineWidth = 2.dp.toPx(),
         )
     }
 }
 
 @Composable
 private fun FocusedItem() {
-    EmotionalBondItem(stringResource(Res.string.emotional_bond_focused)) {
-        val y = size.height / 2
-        val arrowSize = 12.dp.toPx()
-        val unit = Offset(1f, 0f)
-        drawLine(
+    EmotionalBondItem(stringResource(Res.string.emotional_bond_focused)) { p1, p2, nodeSize ->
+        drawEmotionalBondLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            bond = Relationship.EmotionalBond.FOCUSED,
             color = Color.White,
-            start = Offset(0f, y),
-            end = Offset(size.width - arrowSize, y),
-            strokeWidth = 2.dp.toPx(),
-        )
-        drawArrowHead(
-            point = Offset(size.width, y),
-            direction = unit,
-            color = Color.White,
-            strokeWidth = 2.dp.toPx(),
         )
     }
 }
 
 @Composable
 private fun FusedItem() {
-    EmotionalBondItem(stringResource(Res.string.emotional_bond_fused)) {
-        val y = size.height / 2
-        drawLine(
+    EmotionalBondItem(stringResource(Res.string.emotional_bond_fused)) { p1, p2, nodeSize ->
+        drawEmotionalBondLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            bond = Relationship.EmotionalBond.FUSED,
             color = Color.White,
-            start = Offset(0f, y - 4.dp.toPx()),
-            end = Offset(size.width, y - 4.dp.toPx()),
-            strokeWidth = 2.dp.toPx(),
-        )
-        drawLine(
-            color = Color.White,
-            start = Offset(0f, y),
-            end = Offset(size.width, y),
-            strokeWidth = 2.dp.toPx(),
-        )
-        drawLine(
-            color = Color.White,
-            start = Offset(0f, y + 4.dp.toPx()),
-            end = Offset(size.width, y + 4.dp.toPx()),
-            strokeWidth = 2.dp.toPx(),
         )
     }
 }
 
 @Composable
 private fun ConflictualItem() {
-    EmotionalBondItem(stringResource(Res.string.emotional_bond_conflictual)) {
-        drawZigzag(
-            start = Offset(0f, size.height / 2),
-            end = Offset(size.width, size.height / 2),
+    EmotionalBondItem(stringResource(Res.string.emotional_bond_conflictual)) { p1, p2, nodeSize ->
+        drawEmotionalBondLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            bond = Relationship.EmotionalBond.CONFLICTUAL,
             color = Color.White,
-            lineWidth = 2.dp.toPx(),
         )
     }
 }
 
 @Composable
 private fun FusedConflictualItem() {
-    EmotionalBondItem(stringResource(Res.string.emotional_bond_fused_conflictual)) {
-        val y = size.height / 2
-        drawLine(
+    EmotionalBondItem(stringResource(Res.string.emotional_bond_fused_conflictual)) { p1, p2, nodeSize ->
+        drawEmotionalBondLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            bond = Relationship.EmotionalBond.FUSED_CONFLICTUAL,
             color = Color.White,
-            start = Offset(0f, y - 5.dp.toPx()),
-            end = Offset(size.width, y - 5.dp.toPx()),
-            strokeWidth = 2.dp.toPx(),
-        )
-        drawLine(
-            color = Color.White,
-            start = Offset(0f, y),
-            end = Offset(size.width, y),
-            strokeWidth = 2.dp.toPx(),
-        )
-        drawLine(
-            color = Color.White,
-            start = Offset(0f, y + 5.dp.toPx()),
-            end = Offset(size.width, y + 5.dp.toPx()),
-            strokeWidth = 2.dp.toPx(),
-        )
-        drawZigzag(
-            start = Offset(0f, y),
-            end = Offset(size.width, y),
-            color = Color.White,
-            lineWidth = 2.dp.toPx(),
         )
     }
 }
 
 @Composable
 private fun DirectConflictualItem() {
-    EmotionalBondItem(stringResource(Res.string.emotional_bond_direct_conflictual)) {
-        val y = size.height / 2
-        val arrowSize = 12.dp.toPx()
-        val start = Offset(0f, y)
-        val end = Offset(size.width, y)
-        val unit = Offset(1f, 0f)
-        val arrowBase = end - unit * arrowSize
-        drawZigzag(
-            start = start,
-            end = arrowBase,
+    EmotionalBondItem(stringResource(Res.string.emotional_bond_direct_conflictual)) { p1, p2, nodeSize ->
+        drawEmotionalBondLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            bond = Relationship.EmotionalBond.DIRECT_CONFLICTUAL,
             color = Color.White,
-            lineWidth = 2.dp.toPx(),
-        )
-        drawArrowHead(
-            point = end,
-            direction = unit,
-            color = Color.White,
-            strokeWidth = 2.dp.toPx(),
         )
     }
 }
 
 @Composable
 private fun RuptureItem() {
-    EmotionalBondItem(stringResource(Res.string.emotional_bond_rupture)) {
-        val y = size.height / 2
-        val mid = size.width / 2
-        val gap = 12.dp.toPx()
-        drawLine(
+    EmotionalBondItem(stringResource(Res.string.emotional_bond_rupture)) { p1, p2, nodeSize ->
+        drawEmotionalBondLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            bond = Relationship.EmotionalBond.RUPTURE,
             color = Color.White,
-            start = Offset(0f, y),
-            end = Offset(mid - gap / 2, y),
-            strokeWidth = 2.dp.toPx(),
-        )
-        drawLine(
-            color = Color.White,
-            start = Offset(mid + gap / 2, y),
-            end = Offset(size.width, y),
-            strokeWidth = 2.dp.toPx(),
-        )
-        drawLine(
-            color = Color.White,
-            start = Offset(mid - gap / 2, y - 8.dp.toPx()),
-            end = Offset(mid - gap / 2, y + 8.dp.toPx()),
-            strokeWidth = 2.dp.toPx(),
-        )
-        drawLine(
-            color = Color.White,
-            start = Offset(mid + gap / 2, y - 8.dp.toPx()),
-            end = Offset(mid + gap / 2, y + 8.dp.toPx()),
-            strokeWidth = 2.dp.toPx(),
         )
     }
 }
 
 @Composable
 private fun AbuseItem() {
-    EmotionalBondItem(stringResource(Res.string.emotional_bond_abuse)) {
-        val y = size.height / 2
-        val arrowSize = 12.dp.toPx()
-        val unit = Offset(1f, 0f)
-        drawZigzag(
-            start = Offset(0f, y),
-            end = Offset(size.width - arrowSize, y),
-            color = Color.White,
-            lineWidth = 2.dp.toPx(),
-        )
-        drawArrowHead(
-            point = Offset(size.width, y),
-            direction = unit,
-            fill = true,
+    EmotionalBondItem(stringResource(Res.string.emotional_bond_abuse)) { p1, p2, nodeSize ->
+        drawEmotionalBondLine(
+            p1Center = p1,
+            p2Center = p2,
+            nodeSize = nodeSize,
+            bond = Relationship.EmotionalBond.ABUSE,
             color = Color.White,
         )
     }
@@ -914,7 +829,7 @@ private fun AbuseItem() {
 @Composable
 private fun EmotionalBondItem(
     label: String,
-    drawAction: DrawScope.() -> Unit,
+    drawAction: DrawScope.(Offset, Offset, Float) -> Unit,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -929,34 +844,27 @@ private fun EmotionalBondItem(
             modifier = Modifier.weight(1f),
         )
         Spacer(Modifier.width(8.dp))
-        Canvas(modifier = Modifier.width(100.dp).height(24.dp)) {
-            drawAction()
+        Canvas(modifier = Modifier.width(100.dp).height(48.dp)) {
+            val nodeSize = 24.dp.toPx()
+            val strokeWidth = 1.5.dp.toPx()
+            val squareCenter = Offset(nodeSize / 2, size.height / 2)
+            val circleCenter = Offset(size.width - nodeSize / 2, size.height / 2)
+
+            drawRect(
+                color = Color.White,
+                topLeft = Offset(squareCenter.x - nodeSize / 2, squareCenter.y - nodeSize / 2),
+                size = Size(nodeSize, nodeSize),
+                style = Stroke(width = strokeWidth),
+            )
+            drawCircle(
+                color = Color.White,
+                center = circleCenter,
+                radius = nodeSize / 2,
+                style = Stroke(width = strokeWidth),
+            )
+            drawAction(squareCenter, circleCenter, nodeSize)
         }
     }
-}
-
-private fun DrawScope.drawLineHelper(
-    startX: Float,
-    endX: Float,
-    isDashed: Boolean = false,
-    isDotted: Boolean = false,
-) {
-    val y = size.height / 2
-    val strokeWidth = 1.5.dp.toPx()
-    val pathEffect =
-        when {
-            isDashed -> PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f)
-            isDotted -> PathEffect.dashPathEffect(floatArrayOf(3f, 6f), 0f)
-            else -> null
-        }
-
-    drawLine(
-        color = Color.Gray,
-        start = Offset(startX, y),
-        end = Offset(endX, y),
-        strokeWidth = strokeWidth,
-        pathEffect = pathEffect,
-    )
 }
 
 @Preview

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
@@ -72,7 +72,6 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
@@ -86,11 +85,10 @@ import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.model.Relationship
 import dev.saragones3.genogramia.presentation.components.DeletePersonDialog
 import dev.saragones3.genogramia.presentation.components.DeleteTreeDialog
-import dev.saragones3.genogramia.presentation.util.drawArrowHead
 import dev.saragones3.genogramia.presentation.util.drawDeathMark
+import dev.saragones3.genogramia.presentation.util.drawEmotionalBondLine
 import dev.saragones3.genogramia.presentation.util.drawSexualOrientationMark
-import dev.saragones3.genogramia.presentation.util.drawSlashes
-import dev.saragones3.genogramia.presentation.util.drawZigzag
+import dev.saragones3.genogramia.presentation.util.drawStructuralRelationshipLine
 import dev.saragones3.genogramia.presentation.util.femaleNode
 import dev.saragones3.genogramia.presentation.util.maleNode
 import dev.saragones3.genogramia.ui.theme.GenogramiaTheme
@@ -411,7 +409,7 @@ private fun GenogramCanvas(
                                     val centerX = it.position.x * density.density
                                     val centerY = it.position.y * density.density
                                     val personTopLeft =
-                                        Offset(centerX - nodeSize / 2, centerY - nodeSize / 2)
+                                        Offset(centerX - (nodeSize / 2), centerY - (nodeSize / 2))
                                     tapOffset.x >= (personTopLeft.x * scale + offset.x) &&
                                         tapOffset.x <= ((personTopLeft.x + nodeSize) * scale + offset.x) &&
                                         tapOffset.y >= (personTopLeft.y * scale + offset.y) &&
@@ -517,7 +515,7 @@ private fun GridBackground(modifier: Modifier = Modifier) {
         val start = -size / 2
 
         for (i in 0..gridCount) {
-            val pos = start + i * gridStep
+            val pos = start + (i * gridStep)
             drawLine(color, Offset(pos, start), Offset(pos, start + size), 1f)
             drawLine(color, Offset(start, pos), Offset(start + size, pos), 1f)
         }
@@ -563,199 +561,27 @@ private fun DrawScope.drawHorizontalRelationship(
             val p1Center = p1.position * density
             val p2Center = p2.position * density
 
-            val p1IsLeft = p1Center.x < p2Center.x
-            val start =
-                Offset(
-                    if (p1IsLeft) p1Center.x + nodeSize / 2 else p1Center.x - nodeSize / 2,
-                    p1Center.y,
-                )
-            val end =
-                Offset(
-                    if (p1IsLeft) p2Center.x - nodeSize / 2 else p2Center.x + nodeSize / 2,
-                    p2Center.y,
-                )
-
-            val pathEffect =
-                if (relationship.type == Relationship.RelationshipType.COHABITATION ||
-                    relationship.emotionalBond == Relationship.EmotionalBond.DISTANT
-                ) {
-                    PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f)
-                } else {
-                    null
-                }
-
-            val replacesBaseLine =
-                when (relationship.emotionalBond) {
-                    Relationship.EmotionalBond.CONFLICTUAL,
-                    Relationship.EmotionalBond.INTIMATE,
-                    Relationship.EmotionalBond.INTIMATE_CONFLICTUAL,
-                    Relationship.EmotionalBond.DIRECT_CONFLICTUAL,
-                    Relationship.EmotionalBond.ABUSE,
-                    Relationship.EmotionalBond.RUPTURE,
-                    Relationship.EmotionalBond.FOCUSED,
-                    -> true
-
-                    else -> false
-                }
-
-            if (!replacesBaseLine) {
-                drawLine(
-                    color = LINE_COLOR,
-                    start = start,
-                    end = end,
-                    strokeWidth = LINE_WIDTH.toPx(),
-                    pathEffect = pathEffect,
-                )
-            }
-
-            // Draw structural slashes
-            val direction = end - start
-            when (relationship.type) {
-                Relationship.RelationshipType.SEPARATION -> {
-                    drawSlashes((start + end) / 2f, 1, direction)
-                }
-
-                Relationship.RelationshipType.DIVORCE -> {
-                    drawSlashes((start + end) / 2f, 2, direction)
-                }
-
-                Relationship.RelationshipType.RECONCILIATION -> {
-                    drawSlashes(
-                        (start + end) / 2f,
-                        2,
-                        direction,
-                        isReconciliation = true,
-                    )
-                }
-
-                else -> {}
-            }
-
-            // Draw date text
-            if (relationship.dateText.isNotEmpty()) {
-                val textLayoutResult = textMeasurer.measure(relationship.dateText, labelStyle)
-                val textWidth = textLayoutResult.size.width
-                val textHeight = textLayoutResult.size.height
-                val midPoint = (start + end) / 2f
-
-                val hasSlashes =
-                    relationship.type in
-                        listOf(
-                            Relationship.RelationshipType.SEPARATION,
-                            Relationship.RelationshipType.DIVORCE,
-                            Relationship.RelationshipType.RECONCILIATION,
-                        )
-                val slashOffset = if (hasSlashes) 12.dp.toPx() / 2f else 0f
-
-                drawText(
-                    textLayoutResult,
-                    topLeft =
-                        Offset(
-                            midPoint.x - textWidth / 2f,
-                            midPoint.y - slashOffset - textHeight - 4f,
-                        ),
-                )
-            }
-
-            // Draw emotional bond styles
-            drawEmotionalBond(start, end, relationship.emotionalBond)
-        }
-    }
-}
-
-private fun DrawScope.drawEmotionalBond(
-    start: Offset,
-    end: Offset,
-    bond: Relationship.EmotionalBond,
-) {
-    val direction = end - start
-    val length = direction.getDistance()
-    if (length < 1f) return
-    val unit = direction / length
-    val normal = Offset(-unit.y, unit.x)
-
-    when (bond) {
-        Relationship.EmotionalBond.DISTANT -> {
-            // Overdraw with white/background color to create dashes if needed,
-            // or we could have passed pathEffect to drawLine above.
-            // Since we already drew the line, let's just ignore POSITIVE (default)
-        }
-
-        Relationship.EmotionalBond.INTIMATE -> {
-            val offset = normal * 3.dp.toPx()
-            drawLine(LINE_COLOR, start + offset, end + offset, LINE_WIDTH.toPx())
-            drawLine(LINE_COLOR, start - offset, end - offset, LINE_WIDTH.toPx())
-        }
-
-        Relationship.EmotionalBond.FUSED -> {
-            val offset = normal * 5.dp.toPx()
-            drawLine(LINE_COLOR, start + offset, end + offset, LINE_WIDTH.toPx())
-            drawLine(LINE_COLOR, start - offset, end - offset, LINE_WIDTH.toPx())
-            // The main line is already drawn
-        }
-
-        Relationship.EmotionalBond.CONFLICTUAL -> {
-            drawZigzag(start, end, LINE_WIDTH.toPx())
-        }
-
-        Relationship.EmotionalBond.INTIMATE_CONFLICTUAL -> {
-            val offset = normal * 4.dp.toPx()
-            drawLine(LINE_COLOR, start + offset, end + offset, LINE_WIDTH.toPx())
-            drawLine(LINE_COLOR, start - offset, end - offset, LINE_WIDTH.toPx())
-            drawZigzag(start, end, LINE_WIDTH.toPx())
-        }
-
-        Relationship.EmotionalBond.FUSED_CONFLICTUAL -> {
-            val offset = normal * 5.dp.toPx()
-            drawLine(LINE_COLOR, start + offset, end + offset, LINE_WIDTH.toPx())
-            drawLine(LINE_COLOR, start - offset, end - offset, LINE_WIDTH.toPx())
-            drawZigzag(start, end, LINE_WIDTH.toPx())
-        }
-
-        Relationship.EmotionalBond.FOCUSED -> {
-            val arrowSize = 12.dp.toPx()
-            val lineEnd = end - unit * arrowSize
-            drawLine(LINE_COLOR, start, lineEnd, LINE_WIDTH.toPx())
-            drawArrowHead(end, direction)
-        }
-
-        Relationship.EmotionalBond.RUPTURE -> {
-            val mid = (start + end) / 2f
-            val gap = 15.dp.toPx()
-            // Draw the two segments of the line
-            drawLine(LINE_COLOR, start, mid - unit * (gap / 2), LINE_WIDTH.toPx())
-            drawLine(LINE_COLOR, mid + unit * (gap / 2), end, LINE_WIDTH.toPx())
-
-            // We draw two perpendicular bars to indicate the rupture
-            drawLine(
-                color = Color.Black,
-                start = mid - unit * (gap / 2) + normal * 10f,
-                end = mid - unit * (gap / 2) - normal * 10f,
-                strokeWidth = 2.dp.toPx(),
+            drawStructuralRelationshipLine(
+                p1Center = p1Center,
+                p2Center = p2Center,
+                nodeSize = nodeSize,
+                type = relationship.type,
+                dateText = relationship.dateText,
+                textMeasurer = textMeasurer,
+                labelStyle = labelStyle,
+                color = LINE_COLOR,
+                strokeWidth = LINE_WIDTH.toPx(),
             )
-            drawLine(
-                color = Color.Black,
-                start = mid + unit * (gap / 2) + normal * 10f,
-                end = mid + unit * (gap / 2) - normal * 10f,
-                strokeWidth = 2.dp.toPx(),
+
+            drawEmotionalBondLine(
+                p1Center = p1Center,
+                p2Center = p2Center,
+                nodeSize = nodeSize,
+                bond = relationship.emotionalBond,
+                color = LINE_COLOR,
+                strokeWidth = LINE_WIDTH.toPx(),
             )
         }
-
-        Relationship.EmotionalBond.DIRECT_CONFLICTUAL -> {
-            val arrowSize = 12.dp.toPx()
-            val baseEnd = end - unit * arrowSize
-            drawZigzag(start, baseEnd, LINE_WIDTH.toPx())
-            drawArrowHead(end, direction)
-        }
-
-        Relationship.EmotionalBond.ABUSE -> {
-            val arrowSize = 12.dp.toPx()
-            val baseEnd = end - unit * arrowSize
-            drawZigzag(start, baseEnd, LINE_WIDTH.toPx())
-            drawArrowHead(end, direction, fill = true)
-        }
-
-        else -> {}
     }
 }
 
@@ -847,6 +673,7 @@ private fun DrawScope.drawParentStem(
             parentNodes[0].position * density
         }
 
+    val verticalGap = 24.dp.toPx()
     val stemStartY =
         if (parentNodes.size == 2) {
             val p1Id = parentIds[0]
@@ -856,7 +683,11 @@ private fun DrawScope.drawParentStem(
                     (it.personId1 == p1Id && it.personId2 == p2Id) ||
                         (it.personId1 == p2Id && it.personId2 == p1Id)
                 }
-            if (structuralRel != null) parentsMidpointPx.y else parentsMidpointPx.y + nodeSize / 2
+            if (structuralRel != null) {
+                parentsMidpointPx.y + nodeSize / 2 + verticalGap
+            } else {
+                parentsMidpointPx.y + nodeSize / 2
+            }
         } else {
             parentsMidpointPx.y + nodeSize / 2
         }
@@ -1010,7 +841,7 @@ private fun PersonNodeView(
             modifier = nodeModifier,
         )
 
-        Spacer(modifier = Modifier.height(4.dp))
+        Spacer(modifier = Modifier.height(24.dp))
 
         Text(
             text = "${person.firstName} ${person.lastName}",

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/util/DrawUtils.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/util/DrawUtils.kt
@@ -12,16 +12,230 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import dev.saragones3.genogramia.domain.model.Relationship
+
+fun DrawScope.drawStructuralRelationshipLine(
+    p1Center: Offset,
+    p2Center: Offset,
+    nodeSize: Float,
+    type: Relationship.RelationshipType,
+    dateText: String = "",
+    textMeasurer: TextMeasurer? = null,
+    labelStyle: TextStyle? = null,
+    color: Color = Color(0xFFBDBDBD),
+    strokeWidth: Float = 1.5.dp.toPx(),
+) {
+    val verticalGap = 24.dp.toPx()
+    val p1Bottom = Offset(p1Center.x, p1Center.y + (nodeSize / 2))
+    val p2Bottom = Offset(p2Center.x, p2Center.y + (nodeSize / 2))
+
+    val start = Offset(p1Bottom.x, p1Bottom.y + verticalGap)
+    val end = Offset(p2Bottom.x, p2Bottom.y + verticalGap)
+
+    // Draw vertical stems from nodes
+    drawLine(color, p1Bottom, start, strokeWidth)
+    drawLine(color, p2Bottom, end, strokeWidth)
+
+    val pathEffect =
+        if (type == Relationship.RelationshipType.COHABITATION) {
+            PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f)
+        } else {
+            null
+        }
+
+    drawLine(
+        color = color,
+        start = start,
+        end = end,
+        strokeWidth = strokeWidth,
+        pathEffect = pathEffect,
+    )
+
+    // Draw structural slashes
+    val direction = end - start
+    when (type) {
+        Relationship.RelationshipType.SEPARATION -> {
+            drawSlashes(
+                center = (start + end) / 2f,
+                count = 1,
+                direction = direction,
+                color = color,
+                strokeWidth = strokeWidth
+            )
+        }
+
+        Relationship.RelationshipType.DIVORCE -> {
+            drawSlashes(
+                center = (start + end) / 2f,
+                count = 2,
+                direction = direction,
+                color = color,
+                strokeWidth = strokeWidth
+            )
+        }
+
+        Relationship.RelationshipType.RECONCILIATION -> {
+            drawSlashes(
+                center = (start + end) / 2f,
+                count = 2,
+                direction = direction,
+                isReconciliation = true,
+                color = color,
+                strokeWidth = strokeWidth,
+            )
+        }
+
+        else -> {}
+    }
+
+    // Draw date text
+    if (dateText.isNotEmpty() && textMeasurer != null && labelStyle != null) {
+        val textLayoutResult = textMeasurer.measure(dateText, labelStyle)
+        val textWidth = textLayoutResult.size.width
+        val midPoint = (start + end) / 2f
+
+        drawText(
+            textLayoutResult,
+            topLeft =
+                Offset(
+                    midPoint.x - textWidth / 2f,
+                    midPoint.y + 4.dp.toPx(), // Position text below the horizontal line
+                ),
+        )
+    }
+}
+
+fun DrawScope.drawEmotionalBondLine(
+    p1Center: Offset,
+    p2Center: Offset,
+    nodeSize: Float,
+    bond: Relationship.EmotionalBond,
+    color: Color = Color(0xFFBDBDBD),
+    strokeWidth: Float = 1.5.dp.toPx(),
+) {
+    val p1IsLeft = p1Center.x < p2Center.x
+    val start =
+        Offset(
+            if (p1IsLeft) p1Center.x + nodeSize / 2 else p1Center.x - nodeSize / 2,
+            p1Center.y,
+        )
+    val end =
+        Offset(
+            if (p1IsLeft) p2Center.x - nodeSize / 2 else p2Center.x + nodeSize / 2,
+            p2Center.y,
+        )
+
+    val direction = end - start
+    val length = direction.getDistance()
+    if (length < 1f) return
+    val unit = direction / length
+    val normal = Offset(-unit.y, unit.x)
+
+    when (bond) {
+        Relationship.EmotionalBond.POSITIVE -> {
+            drawLine(color, start, end, strokeWidth)
+        }
+
+        Relationship.EmotionalBond.DISTANT -> {
+            drawLine(
+                color = color,
+                start = start,
+                end = end,
+                strokeWidth = strokeWidth,
+                pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f),
+            )
+        }
+
+        Relationship.EmotionalBond.INTIMATE -> {
+            val offset = normal * 8.dp.toPx()
+            drawLine(color, start + offset, end + offset, strokeWidth)
+            drawLine(color, start - offset, end - offset, strokeWidth)
+        }
+
+        Relationship.EmotionalBond.FUSED -> {
+            val offset = normal * 8.dp.toPx()
+            drawLine(color, start + offset, end + offset, strokeWidth)
+            drawLine(color, start, end, strokeWidth)
+            drawLine(color, start - offset, end - offset, strokeWidth)
+        }
+
+        Relationship.EmotionalBond.CONFLICTUAL -> {
+            drawZigzag(start, end, strokeWidth, color)
+        }
+
+        Relationship.EmotionalBond.INTIMATE_CONFLICTUAL -> {
+            val offset = normal * 8.dp.toPx()
+            drawLine(color, start + offset, end + offset, strokeWidth)
+            drawLine(color, start - offset, end - offset, strokeWidth)
+            drawZigzag(start, end, strokeWidth, color)
+        }
+
+        Relationship.EmotionalBond.FUSED_CONFLICTUAL -> {
+            val offset = normal * 8.dp.toPx()
+            drawLine(color, start + offset, end + offset, strokeWidth)
+            drawLine(color, start, end, strokeWidth)
+            drawLine(color, start - offset, end - offset, strokeWidth)
+            drawZigzag(start, end, strokeWidth, color)
+        }
+
+        Relationship.EmotionalBond.FOCUSED -> {
+            val arrowSize = 12.dp.toPx()
+            val lineEnd = end - unit * arrowSize
+            drawLine(color, start, lineEnd, strokeWidth)
+            drawArrowHead(end, direction, color = color, strokeWidth = strokeWidth)
+        }
+
+        Relationship.EmotionalBond.RUPTURE -> {
+            val mid = (start + end) / 2f
+            val gap = 15.dp.toPx()
+            // Draw the two segments of the line
+            drawLine(color, start, mid - unit * (gap / 2), strokeWidth)
+            drawLine(color, mid + unit * (gap / 2), end, strokeWidth)
+
+            // We draw two perpendicular bars to indicate the rupture
+            drawLine(
+                color = color,
+                start = mid - unit * (gap / 2) + normal * 10.dp.toPx(),
+                end = mid - unit * (gap / 2) - normal * 10.dp.toPx(),
+                strokeWidth = 2.dp.toPx(),
+            )
+            drawLine(
+                color = color,
+                start = mid + unit * (gap / 2) + normal * 10.dp.toPx(),
+                end = mid + unit * (gap / 2) - normal * 10.dp.toPx(),
+                strokeWidth = 2.dp.toPx(),
+            )
+        }
+
+        Relationship.EmotionalBond.DIRECT_CONFLICTUAL -> {
+            val arrowSize = 12.dp.toPx()
+            val baseEnd = end - unit * arrowSize
+            drawZigzag(start, baseEnd, strokeWidth, color)
+            drawArrowHead(end, direction, color = color, strokeWidth = strokeWidth)
+        }
+
+        Relationship.EmotionalBond.ABUSE -> {
+            val arrowSize = 12.dp.toPx()
+            val baseEnd = end - unit * arrowSize
+            drawZigzag(start, baseEnd, strokeWidth, color)
+            drawArrowHead(end, direction, fill = true, color = color)
+        }
+    }
+}
 
 fun DrawScope.drawZigzag(
     start: Offset,
     end: Offset,
-    lineWidth: Float = 1.5f,
+    lineWidth: Float = 1.5.dp.toPx(),
     color: Color = Color.Black,
 ) {
     val direction = end - start
@@ -55,7 +269,7 @@ fun DrawScope.drawArrowHead(
     size: Float = 12.dp.toPx(),
     fill: Boolean = false,
     color: Color = Color.Black,
-    strokeWidth: Float = 2f,
+    strokeWidth: Float = 2.dp.toPx(),
 ) {
     val dist = direction.getDistance()
     if (dist < 1f) return


### PR DESCRIPTION
Resolves #144. Rediseño completo de las líneas de relación del canvas genogramático (matrimonio, separación, divorcio, cohabitación, descendencia biológica y adopción) siguiendo el estándar visual definido en LegendsScreen y DrawUtils.