### PR TITLE
[TASK] Sincronización del catálogo CIE11 con persistencia multiplataforma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ captures
 **/xcshareddata/WorkspaceSettings.xcsettings
 node_modules/
 composeApp/genogramia-keystore.jks
+/core/database/schemas/dev.saragones3.genogramia.core.database.GenogramiaDatabase/*.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,10 @@ subprojects {
         )
     }
 
+    dependencies {
+        add("detektPlugins", rootProject.libs.detekt.compose.rules)
+    }
+
     tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
         reports {
             xml.required.set(true)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -33,12 +33,14 @@ val versionBuild = 0
 kotlin {
     applyHierarchyTemplate {
         common {
-            withAndroidTarget()
-            withJvm()
-            group("ios") {
-                withIosArm64()
-                withIosSimulatorArm64()
+            group("mobile") {
+                withAndroidTarget()
+                group("ios") {
+                    withIosArm64()
+                    withIosSimulatorArm64()
+                }
             }
+            withJvm()
             group("web") {
                 withJs()
                 withWasmJs()
@@ -114,6 +116,11 @@ kotlin {
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.serialization.kotlinx.json)
+        }
+        val mobileMain by getting {
+            dependencies {
+                implementation(project(":core:database"))
+            }
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -84,8 +84,11 @@ kotlin {
             implementation(libs.firebase.auth.android)
             implementation(libs.firebase.firestore.android)
             implementation(libs.kotlinx.coroutines.play.services)
+            implementation(libs.ktor.client.okhttp)
+            implementation(libs.okhttp3.logging.interceptor)
         }
         iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
         }
         commonMain.dependencies {
             implementation(libs.compose.runtime)
@@ -106,6 +109,11 @@ kotlin {
             implementation(libs.koin.core)
             implementation(libs.koin.compose)
             implementation(libs.koin.compose.viewmodel)
+
+            // Ktor
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.serialization.kotlinx.json)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
@@ -115,9 +123,12 @@ kotlin {
         jvmMain.dependencies {
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinx.coroutinesSwing)
+            implementation(libs.ktor.client.okhttp)
+            implementation(libs.okhttp3.logging.interceptor)
         }
         webMain.dependencies {
             implementation(npm("firebase", "10.12.0"))
+            implementation(libs.kotlinx.browser)
         }
     }
 }
@@ -153,6 +164,7 @@ android {
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
+            excludes += "/META-INF/versions/9/OSGI-INF/MANIFEST.MF"
         }
     }
     buildTypes {
@@ -166,6 +178,9 @@ android {
             signingConfig = signingConfigs.getByName(name)
             manifestPlaceholders["appName"] = "@string/app_name"
         }
+    }
+    buildFeatures {
+        buildConfig = true
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -28,7 +28,7 @@ val appName = "dev.saragones3.genogramia"
 val versionMajor = 1
 val versionMinor = 0
 val versionPatch = 2
-val versionBuild = 0
+val versionBuild = 1
 
 kotlin {
     applyHierarchyTemplate {

--- a/composeApp/src/androidMain/kotlin/dev/saragones3/genogramia/di/PlatformModule.kt
+++ b/composeApp/src/androidMain/kotlin/dev/saragones3/genogramia/di/PlatformModule.kt
@@ -2,12 +2,18 @@ package dev.saragones3.genogramia.di
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import dev.saragones3.genogramia.BuildConfig
 import dev.saragones3.genogramia.data.remote.FirebaseProvider
 import dev.saragones3.genogramia.data.remote.FirebaseProviderImpl
 import dev.saragones3.genogramia.data.remote.FirestoreProvider
 import dev.saragones3.genogramia.data.remote.FirestoreProviderImpl
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.okhttp.OkHttp
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import org.koin.core.module.Module
 import org.koin.dsl.module
+import java.util.concurrent.TimeUnit
 
 actual fun platformDataModule(): Module =
     module {
@@ -15,4 +21,26 @@ actual fun platformDataModule(): Module =
         single { FirebaseFirestore.getInstance() }
         single<FirebaseProvider> { FirebaseProviderImpl(get()) }
         single<FirestoreProvider> { FirestoreProviderImpl(get()) }
+        single<HttpClientEngine> {
+            OkHttp.create {
+                val interceptor =
+                    HttpLoggingInterceptor().apply {
+                        level =
+                            if (BuildConfig.DEBUG) {
+                                HttpLoggingInterceptor.Level.HEADERS
+                            } else {
+                                HttpLoggingInterceptor.Level.NONE
+                            }
+                    }
+                preconfigured =
+                    OkHttpClient
+                        .Builder()
+                        .addInterceptor(interceptor)
+                        .connectTimeout(2, TimeUnit.MINUTES)
+                        .readTimeout(60, TimeUnit.SECONDS)
+                        .writeTimeout(30, TimeUnit.SECONDS)
+                        .followRedirects(false)
+                        .build()
+            }
+        }
     }

--- a/composeApp/src/androidMain/kotlin/dev/saragones3/genogramia/util/Localization.kt
+++ b/composeApp/src/androidMain/kotlin/dev/saragones3/genogramia/util/Localization.kt
@@ -1,0 +1,5 @@
+package dev.saragones3.genogramia.util
+
+import java.util.Locale
+
+actual fun getAppLanguage(): String = Locale.getDefault().language

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/remote/DiseasesMapper.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/remote/DiseasesMapper.kt
@@ -1,0 +1,18 @@
+package dev.saragones3.genogramia.data.remote
+
+import dev.saragones3.genogramia.data.remote.model.Cie11ChapterDto
+import dev.saragones3.genogramia.domain.model.Disease
+import dev.saragones3.genogramia.util.getAppLanguage
+
+fun Cie11ChapterDto.toDomainList(): List<Disease> {
+    val lang = getAppLanguage()
+    return subcategories.map {
+        Disease(
+            code = it.code,
+            title = if (lang == "es") it.title.es.ifEmpty { it.title.en } else it.title.en.ifEmpty { it.title.es },
+            chapterCode = code,
+            chapterTitle = if (lang == "es") title.es.ifEmpty { title.en } else title.en.ifEmpty { title.es },
+            isGenetic = it.isGenetic,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/remote/DiseasesRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/remote/DiseasesRemoteDataSource.kt
@@ -1,0 +1,38 @@
+package dev.saragones3.genogramia.data.remote
+
+import dev.saragones3.genogramia.data.remote.model.Cie11ChapterDto
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+
+class DiseasesRemoteDataSource(
+    private val httpClient: HttpClient,
+) {
+    companion object {
+        private const val CHAPTER_BASE = "/cie11_capitulo_"
+        private val CHAPTERS =
+            listOf(
+                "02",
+                "03",
+                "04",
+                "05",
+                "06",
+                "07",
+                "08",
+                "09",
+                "10",
+                "11",
+                "12",
+                "13",
+                "14",
+                "15",
+                "16",
+                "17",
+                "20",
+            )
+    }
+
+    fun getChapters(): List<String> = CHAPTERS
+
+    suspend fun getChapter(chapter: String): Cie11ChapterDto = httpClient.get("$CHAPTER_BASE$chapter.json").body()
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/remote/model/Cie11Dto.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/remote/model/Cie11Dto.kt
@@ -1,0 +1,32 @@
+package dev.saragones3.genogramia.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Cie11ChapterDto(
+    @SerialName("codigo")
+    val code: String,
+    @SerialName("titulo")
+    val title: Cie11TitleDto,
+    @SerialName("lastSync")
+    val lastSync: String,
+    @SerialName("subcategorias")
+    val subcategories: List<Cie11SubcategoryDto>,
+)
+
+@Serializable
+data class Cie11TitleDto(
+    val es: String = "",
+    val en: String = "",
+)
+
+@Serializable
+data class Cie11SubcategoryDto(
+    @SerialName("codigo")
+    val code: String,
+    @SerialName("titulo")
+    val title: Cie11TitleDto,
+    @SerialName("isGenetic")
+    val isGenetic: Boolean,
+)

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/repository/InMemoryDiseaseRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/repository/InMemoryDiseaseRepository.kt
@@ -1,0 +1,34 @@
+package dev.saragones3.genogramia.data.repository
+
+import dev.saragones3.genogramia.data.remote.DiseasesRemoteDataSource
+import dev.saragones3.genogramia.data.remote.toDomainList
+import dev.saragones3.genogramia.domain.model.Disease
+import dev.saragones3.genogramia.domain.repository.DiseaseRepository
+
+class InMemoryDiseaseRepository(
+    private val remoteDataSource: DiseasesRemoteDataSource,
+) : DiseaseRepository {
+    private val cache = mutableMapOf<String, List<Disease>>()
+
+    override suspend fun getDiseasesByChapter(chapterCode: String): List<Disease> = cache[chapterCode] ?: emptyList()
+
+    override suspend fun searchDiseases(query: String): List<Disease> {
+        val q = query.lowercase()
+        return cache.values
+            .flatten()
+            .filter {
+                it.title.lowercase().contains(q)
+            }
+    }
+
+    override suspend fun syncCatalog() {
+        remoteDataSource.getChapters().forEach { chapterCode ->
+            try {
+                val chapterDto = remoteDataSource.getChapter(chapterCode)
+                cache[chapterCode] = chapterDto.toDomainList()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
@@ -23,6 +23,7 @@ import dev.saragones3.genogramia.domain.usecase.SendPasswordResetEmailUseCase
 import dev.saragones3.genogramia.domain.usecase.SignInUseCase
 import dev.saragones3.genogramia.domain.usecase.SignOutUseCase
 import dev.saragones3.genogramia.domain.usecase.SignUpUseCase
+import dev.saragones3.genogramia.domain.usecase.SyncDiseasesCatalogUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdatePasswordUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdatePersonUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdateTreeUseCase
@@ -134,6 +135,7 @@ private val domainModule =
         factoryOf(::GetPersonUseCase)
         factoryOf(::GetTreesUseCase)
         factoryOf(::GetTreeUseCase)
+        factoryOf(::SyncDiseasesCatalogUseCase)
         factoryOf(::DateFormatter)
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
@@ -1,5 +1,6 @@
 package dev.saragones3.genogramia.di
 
+import dev.saragones3.genogramia.data.remote.DiseasesRemoteDataSource
 import dev.saragones3.genogramia.data.repository.AuthRepositoryImpl
 import dev.saragones3.genogramia.data.repository.FirestoreTreeRepository
 import dev.saragones3.genogramia.data.repository.InMemoryTreeRepository
@@ -40,10 +41,20 @@ import dev.saragones3.genogramia.presentation.registration.RegistrationViewModel
 import dev.saragones3.genogramia.presentation.settings.SettingsViewModel
 import dev.saragones3.genogramia.presentation.splash.SplashViewModel
 import dev.saragones3.genogramia.presentation.tree.TreeViewModel
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.URLProtocol
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
+
+private const val BASE_DISEASES_URL = "cie11-diseases.web.app"
 
 private val dataModule =
     module {
@@ -78,6 +89,29 @@ private val dataModule =
         }
 
         single<DateProvider> { RealDateProvider() }
+
+        single<HttpClient> {
+            val httpClientEngine = get<HttpClientEngine>()
+            HttpClient(httpClientEngine) {
+                engine {
+                    httpClientEngine.config
+                }
+            }.config {
+                install(ContentNegotiation) {
+                    json(
+                        json = Json { ignoreUnknownKeys = true },
+                        contentType = ContentType.Application.Json,
+                    )
+                }
+                install(DefaultRequest) {
+                    url {
+                        protocol = URLProtocol.HTTPS
+                        host = BASE_DISEASES_URL
+                    }
+                }
+            }
+        }
+        single { DiseasesRemoteDataSource(get()) }
     }
 
 private val domainModule =

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
@@ -156,6 +156,7 @@ private val appModule =
 
 fun getSharedModules(): List<Module> =
     listOf(
+        localDataSourceModule(),
         platformDataModule(),
         dataModule,
         domainModule,

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/LocalDataSourceModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/LocalDataSourceModule.kt
@@ -1,0 +1,5 @@
+package dev.saragones3.genogramia.di
+
+import org.koin.core.module.Module
+
+expect fun localDataSourceModule(): Module

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/model/Disease.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/model/Disease.kt
@@ -1,0 +1,9 @@
+package dev.saragones3.genogramia.domain.model
+
+data class Disease(
+    val code: String,
+    val title: String,
+    val chapterCode: String,
+    val chapterTitle: String,
+    val isGenetic: Boolean,
+)

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/repository/DiseaseRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/repository/DiseaseRepository.kt
@@ -1,0 +1,11 @@
+package dev.saragones3.genogramia.domain.repository
+
+import dev.saragones3.genogramia.domain.model.Disease
+
+interface DiseaseRepository {
+    suspend fun getDiseasesByChapter(chapterCode: String): List<Disease>
+
+    suspend fun searchDiseases(query: String): List<Disease>
+
+    suspend fun syncCatalog()
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/SyncDiseasesCatalogUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/SyncDiseasesCatalogUseCase.kt
@@ -1,0 +1,9 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.repository.DiseaseRepository
+
+class SyncDiseasesCatalogUseCase(
+    private val repository: DiseaseRepository,
+) {
+    suspend operator fun invoke() = repository.syncCatalog()
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/splash/SplashViewModel.kt
@@ -3,6 +3,7 @@ package dev.saragones3.genogramia.presentation.splash
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
+import dev.saragones3.genogramia.domain.usecase.SyncDiseasesCatalogUseCase
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
@@ -10,10 +11,14 @@ import kotlinx.coroutines.flow.stateIn
 
 class SplashViewModel(
     private val checkSession: CheckSessionUseCase,
+    private val syncCie11Catalog: SyncDiseasesCatalogUseCase,
 ) : ViewModel() {
     val uiState: StateFlow<SplashUiState> =
         flow {
             emit(SplashUiState.Loading)
+
+            syncCie11Catalog()
+
             val user = checkSession()
             emit(
                 if (user != null) {

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/util/Localization.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/util/Localization.kt
@@ -1,0 +1,3 @@
+package dev.saragones3.genogramia.util
+
+expect fun getAppLanguage(): String

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/SyncDiseasesCatalogUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/SyncDiseasesCatalogUseCaseTest.kt
@@ -1,0 +1,19 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.fakes.FakeDiseaseRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SyncDiseasesCatalogUseCaseTest {
+    private val repository = FakeDiseaseRepository()
+    private val useCase = SyncDiseasesCatalogUseCase(repository)
+
+    @Test
+    fun `GIVEN a catalog WHEN sync THEN triggers repository sync`() =
+        runTest {
+            useCase()
+
+            assertTrue(repository.synced)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeDiseaseRepository.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeDiseaseRepository.kt
@@ -1,0 +1,21 @@
+package dev.saragones3.genogramia.fakes
+
+import dev.saragones3.genogramia.domain.model.Disease
+import dev.saragones3.genogramia.domain.repository.DiseaseRepository
+
+class FakeDiseaseRepository : DiseaseRepository {
+    var diseases = emptyList<Disease>()
+    var synced = false
+
+    override suspend fun getDiseasesByChapter(chapterCode: String): List<Disease> =
+        diseases.filter {
+            it.chapterCode ==
+                chapterCode
+        }
+
+    override suspend fun searchDiseases(query: String): List<Disease> = diseases.filter { it.title.contains(query) }
+
+    override suspend fun syncCatalog() {
+        synced = true
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/splash/SplashViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/splash/SplashViewModelTest.kt
@@ -3,7 +3,9 @@ package dev.saragones3.genogramia.presentation.splash
 import app.cash.turbine.test
 import dev.saragones3.genogramia.domain.model.User
 import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
+import dev.saragones3.genogramia.domain.usecase.SyncDiseasesCatalogUseCase
 import dev.saragones3.genogramia.fakes.FakeAuthRepository
+import dev.saragones3.genogramia.fakes.FakeDiseaseRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -14,10 +16,13 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SplashViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
+    private val repository = FakeDiseaseRepository()
+    private val syncUseCase = SyncDiseasesCatalogUseCase(repository)
 
     @BeforeTest
     fun setup() {
@@ -30,26 +35,28 @@ class SplashViewModelTest {
     }
 
     @Test
-    fun `GIVEN logged in user WHEN view model initialized THEN navigates to authenticated home`() =
+    fun `GIVEN logged in user WHEN view model initialized THEN syncs catalog and navigates to authenticated home`() =
         runTest {
             val fakeRepo = FakeAuthRepository(User("uid", "email", "name"))
             val useCase = CheckSessionUseCase(fakeRepo)
-            val viewModel = SplashViewModel(useCase)
+            val viewModel = SplashViewModel(useCase, syncUseCase)
 
             viewModel.uiState.test {
                 assertEquals(SplashUiState.NavigateToAuthenticatedHome, awaitItem())
+                assertTrue(repository.synced)
             }
         }
 
     @Test
-    fun `GIVEN no user WHEN view model initialized THEN navigates to guest home`() =
+    fun `GIVEN no user WHEN view model initialized THEN syncs catalog and navigates to guest home`() =
         runTest {
             val fakeRepo = FakeAuthRepository(null)
             val useCase = CheckSessionUseCase(fakeRepo)
-            val viewModel = SplashViewModel(useCase)
+            val viewModel = SplashViewModel(useCase, syncUseCase)
 
             viewModel.uiState.test {
                 assertEquals(SplashUiState.NavigateToGuestHome, awaitItem())
+                assertTrue(repository.synced)
             }
         }
 }

--- a/composeApp/src/iosMain/kotlin/dev/saragones3/genogramia/di/PlatformModule.kt
+++ b/composeApp/src/iosMain/kotlin/dev/saragones3/genogramia/di/PlatformModule.kt
@@ -6,6 +6,8 @@ import dev.saragones3.genogramia.data.remote.FirebaseProviderImpl
 import dev.saragones3.genogramia.data.remote.FirestoreDelegate
 import dev.saragones3.genogramia.data.remote.FirestoreProvider
 import dev.saragones3.genogramia.data.remote.FirestoreProviderImpl
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.darwin.Darwin
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
@@ -22,4 +24,11 @@ internal fun iosFirebaseModule(
     module {
         single<FirebaseProvider> { FirebaseProviderImpl(authDelegate) }
         single<FirestoreProvider> { FirestoreProviderImpl(firestoreDelegate) }
+        single<HttpClientEngine> {
+            Darwin.create {
+                configureRequest {
+                    setAllowsCellularAccess(true)
+                }
+            }
+        }
     }

--- a/composeApp/src/iosMain/kotlin/dev/saragones3/genogramia/util/Localization.kt
+++ b/composeApp/src/iosMain/kotlin/dev/saragones3/genogramia/util/Localization.kt
@@ -1,0 +1,7 @@
+package dev.saragones3.genogramia.util
+
+import platform.Foundation.NSLocale
+import platform.Foundation.currentLocale
+import platform.Foundation.languageCode
+
+actual fun getAppLanguage(): String = NSLocale.currentLocale.languageCode

--- a/composeApp/src/jvmMain/kotlin/dev/saragones3/genogramia/di/LocalDataSourceModule.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/dev/saragones3/genogramia/di/LocalDataSourceModule.jvm.kt
@@ -1,0 +1,11 @@
+package dev.saragones3.genogramia.di
+
+import dev.saragones3.genogramia.data.repository.InMemoryDiseaseRepository
+import dev.saragones3.genogramia.domain.repository.DiseaseRepository
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual fun localDataSourceModule(): Module =
+    module {
+        single<DiseaseRepository> { InMemoryDiseaseRepository(get()) }
+    }

--- a/composeApp/src/jvmMain/kotlin/dev/saragones3/genogramia/di/PlatformModule.kt
+++ b/composeApp/src/jvmMain/kotlin/dev/saragones3/genogramia/di/PlatformModule.kt
@@ -4,11 +4,30 @@ import dev.saragones3.genogramia.data.remote.FirebaseProvider
 import dev.saragones3.genogramia.data.remote.FirebaseProviderImpl
 import dev.saragones3.genogramia.data.remote.FirestoreProvider
 import dev.saragones3.genogramia.data.remote.FirestoreProviderImpl
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.okhttp.OkHttp
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import org.koin.core.module.Module
 import org.koin.dsl.module
+import java.util.concurrent.TimeUnit
 
 actual fun platformDataModule(): Module =
     module {
         single<FirebaseProvider> { FirebaseProviderImpl() }
         single<FirestoreProvider> { FirestoreProviderImpl() }
+        single<HttpClientEngine> {
+            OkHttp.create {
+                val interceptor = HttpLoggingInterceptor()
+                preconfigured =
+                    OkHttpClient
+                        .Builder()
+                        .addInterceptor(interceptor)
+                        .connectTimeout(2, TimeUnit.MINUTES)
+                        .readTimeout(60, TimeUnit.SECONDS)
+                        .writeTimeout(30, TimeUnit.SECONDS)
+                        .followRedirects(false)
+                        .build()
+            }
+        }
     }

--- a/composeApp/src/jvmMain/kotlin/dev/saragones3/genogramia/util/Localization.kt
+++ b/composeApp/src/jvmMain/kotlin/dev/saragones3/genogramia/util/Localization.kt
@@ -1,0 +1,5 @@
+package dev.saragones3.genogramia.util
+
+import java.util.Locale
+
+actual fun getAppLanguage(): String = Locale.getDefault().language

--- a/composeApp/src/mobileMain/kotlin/dev/saragones3/genogramia/data/repository/RoomDiseaseRepository.kt
+++ b/composeApp/src/mobileMain/kotlin/dev/saragones3/genogramia/data/repository/RoomDiseaseRepository.kt
@@ -1,0 +1,63 @@
+package dev.saragones3.genogramia.data.repository
+
+import dev.saragones3.genogramia.core.database.DiseaseDao
+import dev.saragones3.genogramia.core.database.model.ChapterSyncEntity
+import dev.saragones3.genogramia.core.database.model.DiseaseEntity
+import dev.saragones3.genogramia.data.remote.DiseasesRemoteDataSource
+import dev.saragones3.genogramia.data.remote.toDomainList
+import dev.saragones3.genogramia.domain.model.Disease
+import dev.saragones3.genogramia.domain.repository.DiseaseRepository
+
+class RoomDiseaseRepository(
+    private val remoteDataSource: DiseasesRemoteDataSource,
+    private val dao: DiseaseDao,
+) : DiseaseRepository {
+    override suspend fun getDiseasesByChapter(chapterCode: String): List<Disease> =
+        dao.getDiseasesByChapter(chapterCode).map {
+            it.toDomain()
+        }
+
+    override suspend fun searchDiseases(query: String): List<Disease> = dao.searchDiseases(query).map { it.toDomain() }
+
+    override suspend fun syncCatalog() {
+        remoteDataSource.getChapters().forEach { chapterCode ->
+            try {
+                val localSync = dao.getChapterSync(chapterCode)
+                val chapterDto = remoteDataSource.getChapter(chapterCode)
+
+                val localSyncDate = localSync?.lastSyncDate
+                val remoteSyncDate = chapterDto.lastSync
+
+                if (remoteSyncDate != localSyncDate) {
+                    val diseases = chapterDto.toDomainList()
+                    dao.replaceChapterData(
+                        chapterCode = chapterCode,
+                        lastSyncDate = remoteSyncDate,
+                        diseases = diseases.map { it.toEntity() },
+                    )
+                }
+            } catch (e: Exception) {
+                // Ignore sync errors for specific chapters to allow partial syncs
+                e.printStackTrace()
+            }
+        }
+    }
+}
+
+fun DiseaseEntity.toDomain() =
+    Disease(
+        code = code,
+        title = title,
+        chapterCode = chapterCode,
+        chapterTitle = chapterTitle,
+        isGenetic = isGenetic,
+    )
+
+fun Disease.toEntity() =
+    DiseaseEntity(
+        code = code,
+        title = title,
+        chapterCode = chapterCode,
+        chapterTitle = chapterTitle,
+        isGenetic = isGenetic,
+    )

--- a/composeApp/src/mobileMain/kotlin/dev/saragones3/genogramia/di/LocalDataSourceModule.mobile.kt
+++ b/composeApp/src/mobileMain/kotlin/dev/saragones3/genogramia/di/LocalDataSourceModule.mobile.kt
@@ -1,0 +1,13 @@
+package dev.saragones3.genogramia.di
+
+import dev.saragones3.genogramia.core.database.di.databaseModule
+import dev.saragones3.genogramia.data.repository.RoomDiseaseRepository
+import dev.saragones3.genogramia.domain.repository.DiseaseRepository
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual fun localDataSourceModule(): Module =
+    module {
+        includes(databaseModule)
+        single<DiseaseRepository> { RoomDiseaseRepository(get(), get()) }
+    }

--- a/composeApp/src/webMain/kotlin/dev/saragones3/genogramia/di/LocalDataSourceModule.web.kt
+++ b/composeApp/src/webMain/kotlin/dev/saragones3/genogramia/di/LocalDataSourceModule.web.kt
@@ -1,0 +1,11 @@
+package dev.saragones3.genogramia.di
+
+import dev.saragones3.genogramia.data.repository.InMemoryDiseaseRepository
+import dev.saragones3.genogramia.domain.repository.DiseaseRepository
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual fun localDataSourceModule(): Module =
+    module {
+        single<DiseaseRepository> { InMemoryDiseaseRepository(get()) }
+    }

--- a/composeApp/src/webMain/kotlin/dev/saragones3/genogramia/di/PlatformModule.kt
+++ b/composeApp/src/webMain/kotlin/dev/saragones3/genogramia/di/PlatformModule.kt
@@ -4,6 +4,8 @@ import dev.saragones3.genogramia.data.remote.FirebaseProvider
 import dev.saragones3.genogramia.data.remote.FirebaseProviderImpl
 import dev.saragones3.genogramia.data.remote.FirestoreProvider
 import dev.saragones3.genogramia.data.remote.FirestoreProviderImpl
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
@@ -11,4 +13,5 @@ actual fun platformDataModule(): Module =
     module {
         single<FirebaseProvider> { FirebaseProviderImpl() }
         single<FirestoreProvider> { FirestoreProviderImpl() }
+        single<HttpClientEngine> { HttpClient().engine }
     }

--- a/composeApp/src/webMain/kotlin/dev/saragones3/genogramia/util/Localization.kt
+++ b/composeApp/src/webMain/kotlin/dev/saragones3/genogramia/util/Localization.kt
@@ -1,0 +1,5 @@
+package dev.saragones3.genogramia.util
+
+import kotlinx.browser.window
+
+actual fun getAppLanguage(): String = window.navigator.language.split("-")[0]

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -1,0 +1,85 @@
+@file:OptIn(ExperimentalKotlinGradlePluginApi::class)
+
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.androidx.room)
+}
+
+room {
+    schemaDirectory("$projectDir/schemas")
+}
+
+kotlin {
+    applyHierarchyTemplate {
+        common {
+            withAndroidTarget()
+            group("ios") {
+                withIosArm64()
+                withIosSimulatorArm64()
+            }
+        }
+    }
+
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
+
+    listOf(
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach { iosTarget ->
+        iosTarget.binaries.framework {
+            baseName = "Database"
+            isStatic = true
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            api(libs.androidx.room.runtime)
+            implementation(libs.koin.core)
+            implementation(libs.kotlinx.serialization.json)
+        }
+
+        androidMain.dependencies {
+            implementation(libs.koin.android)
+        }
+
+        iosMain.dependencies {
+            implementation(libs.androidx.sqlite.bundled)
+        }
+    }
+}
+
+android {
+    namespace = "dev.saragones3.genogramia.core.database"
+    compileSdk =
+        libs.versions.android.compileSdk
+            .get()
+            .toInt()
+
+    defaultConfig {
+        minSdk =
+            libs.versions.android.minSdk
+                .get()
+                .toInt()
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+dependencies {
+    add("kspAndroid", libs.androidx.room.compiler)
+    add("kspIosArm64", libs.androidx.room.compiler)
+    add("kspIosSimulatorArm64", libs.androidx.room.compiler)
+}

--- a/core/database/src/androidMain/kotlin/dev/saragones3/genogramia/core/database/di/PlatformModule.android.kt
+++ b/core/database/src/androidMain/kotlin/dev/saragones3/genogramia/core/database/di/PlatformModule.android.kt
@@ -1,0 +1,22 @@
+package dev.saragones3.genogramia.core.database.di
+
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.sqlite.driver.AndroidSQLiteDriver
+import dev.saragones3.genogramia.core.database.GenogramiaDatabase
+import kotlinx.coroutines.Dispatchers
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+actual val platformModule =
+    module {
+        single<RoomDatabase.Builder<GenogramiaDatabase>> {
+            Room
+                .databaseBuilder(
+                    context = get(),
+                    klass = GenogramiaDatabase::class.java,
+                    name = get(named("database_name")),
+                ).setDriver(AndroidSQLiteDriver())
+                .setQueryCoroutineContext(Dispatchers.IO)
+        }
+    }

--- a/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/DiseaseDao.kt
+++ b/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/DiseaseDao.kt
@@ -1,0 +1,43 @@
+package dev.saragones3.genogramia.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import dev.saragones3.genogramia.core.database.model.ChapterSyncEntity
+import dev.saragones3.genogramia.core.database.model.DiseaseEntity
+
+@Dao
+interface DiseaseDao {
+    @Query("SELECT * FROM disease WHERE chapterCode = :chapterCode")
+    suspend fun getDiseasesByChapter(chapterCode: String): List<DiseaseEntity>
+
+    @Query(
+        "SELECT * FROM disease WHERE title LIKE '%' || :query || '%'",
+    )
+    suspend fun searchDiseases(query: String): List<DiseaseEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertDiseases(diseases: List<DiseaseEntity>)
+
+    @Query("DELETE FROM disease WHERE chapterCode = :chapterCode")
+    suspend fun deleteDiseasesByChapter(chapterCode: String)
+
+    @Query("SELECT * FROM chapter_sync WHERE chapterCode = :chapterCode")
+    suspend fun getChapterSync(chapterCode: String): ChapterSyncEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertChapterSync(syncEntity: ChapterSyncEntity)
+
+    @Transaction
+    suspend fun replaceChapterData(
+        chapterCode: String,
+        lastSyncDate: String,
+        diseases: List<DiseaseEntity>,
+    ) {
+        deleteDiseasesByChapter(chapterCode)
+        insertDiseases(diseases)
+        insertChapterSync(ChapterSyncEntity(chapterCode, lastSyncDate))
+    }
+}

--- a/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/GenogramiaDatabase.kt
+++ b/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/GenogramiaDatabase.kt
@@ -1,0 +1,17 @@
+package dev.saragones3.genogramia.core.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import dev.saragones3.genogramia.core.database.model.ChapterSyncEntity
+import dev.saragones3.genogramia.core.database.model.DiseaseEntity
+
+@Database(
+    entities = [
+        DiseaseEntity::class,
+        ChapterSyncEntity::class,
+    ],
+    version = 1,
+)
+abstract class GenogramiaDatabase : RoomDatabase() {
+    abstract fun diseaseDao(): DiseaseDao
+}

--- a/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/di/DatabaseModule.kt
+++ b/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/di/DatabaseModule.kt
@@ -1,0 +1,20 @@
+package dev.saragones3.genogramia.core.database.di
+
+import androidx.room.RoomDatabase
+import dev.saragones3.genogramia.core.database.DiseaseDao
+import dev.saragones3.genogramia.core.database.GenogramiaDatabase
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+private const val DATABASE_NAME = "GenogramIA"
+
+val databaseModule =
+    module {
+        includes(platformModule)
+        single<String>(named("database_name")) { DATABASE_NAME }
+        single<GenogramiaDatabase> {
+            val builder = get<RoomDatabase.Builder<GenogramiaDatabase>>()
+            builder.build()
+        }
+        single<DiseaseDao> { get<GenogramiaDatabase>().diseaseDao() }
+    }

--- a/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/di/PlatformModule.kt
+++ b/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/di/PlatformModule.kt
@@ -1,0 +1,5 @@
+package dev.saragones3.genogramia.core.database.di
+
+import org.koin.core.module.Module
+
+expect val platformModule: Module

--- a/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/model/ChapterSyncEntity.kt
+++ b/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/model/ChapterSyncEntity.kt
@@ -1,0 +1,11 @@
+package dev.saragones3.genogramia.core.database.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "chapter_sync")
+data class ChapterSyncEntity(
+    @PrimaryKey
+    val chapterCode: String,
+    val lastSyncDate: String,
+)

--- a/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/model/DiseaseEntity.kt
+++ b/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/model/DiseaseEntity.kt
@@ -1,0 +1,14 @@
+package dev.saragones3.genogramia.core.database.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "disease")
+data class DiseaseEntity(
+    @PrimaryKey
+    val code: String,
+    val title: String,
+    val chapterCode: String,
+    val chapterTitle: String,
+    val isGenetic: Boolean,
+)

--- a/core/database/src/iosMain/kotlin/dev/saragones3/genogramia/core/database/di/PlatformModule.ios.kt
+++ b/core/database/src/iosMain/kotlin/dev/saragones3/genogramia/core/database/di/PlatformModule.ios.kt
@@ -1,0 +1,40 @@
+package dev.saragones3.genogramia.core.database.di
+
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import dev.saragones3.genogramia.core.database.GenogramiaDatabase
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSURL
+import platform.Foundation.NSUserDomainMask
+
+actual val platformModule =
+    module {
+        single<RoomDatabase.Builder<GenogramiaDatabase>> {
+            val dbName: String = get(named("database_name"))
+            val dbFile = "${fileDirectory()}/$dbName"
+            Room
+                .databaseBuilder<GenogramiaDatabase>(dbFile)
+                .setDriver(BundledSQLiteDriver())
+                .setQueryCoroutineContext(Dispatchers.IO)
+        }
+    }
+
+@OptIn(ExperimentalForeignApi::class)
+private fun fileDirectory(): String {
+    val documentDirectory: NSURL? =
+        NSFileManager.defaultManager.URLForDirectory(
+            directory = NSDocumentDirectory,
+            inDomain = NSUserDomainMask,
+            appropriateForURL = null,
+            create = false,
+            error = null,
+        )
+    return requireNotNull(documentDirectory).path!!
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,14 +16,17 @@ junit = "4.13.2"
 kotlin = "2.3.20"
 kotlinx-coroutines = "1.9.0"
 kotlinx-serialization = "1.8.0"
+ktor = "3.1.1"
 material3 = "1.9.0"
 navigation3 = "1.1.0"
+okhttp3 = "5.4.0"
 spotless = "8.4.0"
 detekt = "1.23.8"
 compose-rules = "0.4.22"
 koin = "4.1.1"
 turbine = "1.1.0"
 kotlinx-datetime = "0.8.0"
+kotlinx-browser = "0.5.0"
 firebase = "33.14.0"
 google-services = "4.4.2"
 
@@ -54,6 +57,12 @@ koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
 koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+okhttp3-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp3" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase" }
 firebase-auth-android = { module = "com.google.firebase:firebase-auth" }
 firebase-firestore-android = { module = "com.google.firebase:firebase-firestore" }
@@ -62,6 +71,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 detekt-compose-rules = { module = "io.nlopez.compose.rules:detekt", version.ref = "compose-rules" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
+kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,11 +16,14 @@ junit = "4.13.2"
 kotlin = "2.3.20"
 kotlinx-coroutines = "1.9.0"
 kotlinx-serialization = "1.8.0"
+ksp = "2.3.9"
 ktor = "3.1.1"
 material3 = "1.9.0"
 navigation3 = "1.1.0"
 okhttp3 = "5.4.0"
+room = "2.8.4"
 spotless = "8.4.0"
+sqlite = "2.7.0"
 detekt = "1.23.8"
 compose-rules = "0.4.22"
 koin = "4.1.1"
@@ -31,6 +34,9 @@ firebase = "33.14.0"
 google-services = "4.4.2"
 
 [libraries]
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 junit = { module = "junit:junit", version.ref = "junit" }
@@ -74,6 +80,7 @@ kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
 
 [plugins]
+androidx-room = { id = "androidx.room", version.ref = "room" }
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "composeHotReload" }
@@ -81,6 +88,7 @@ composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMul
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 googleServices = { id = "com.google.gms.google-services", version.ref = "google-services" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,3 +33,4 @@ plugins {
 }
 
 include(":composeApp")
+include(":core:database")


### PR DESCRIPTION
Implementa la carga y persistencia del catálogo de enfermedades CIE11 desde múltiples URLs Firebase Storage con estrategia multiplataforma diferenciada:

- **Android / iOS**: Almacenamiento local persistente con Room, sincronizando capítulos si no están sincronizados o si ha pasado más de un mes desde la última sincronización.
- **Web / Desktop**: Almacenamiento temporal en memoria a través de una caché de variables de sesión.

### Cambios Introducidos
1. **Módulo core:database**:
   - Entidad DiseaseEntity y ChapterSyncEntity.
   - DAO DiseaseDao con inserción, consulta de enfermedades por código y consulta de capítulos sincronizados.
   - Configuración de Room Multiplatform con @ConstructedBy y GenogramiaDatabaseConstructor.
2. **Fuentes de Datos y Repositorios**:
   - DiseasesRemoteDataSource para realizar peticiones HTTP Ktor y obtener los JSON del catálogo de enfermedades.
   - InMemoryDiseaseRepository para Desktop y Web.
   - RoomDiseaseRepository para Android e iOS.
3. **Casos de Uso**:
   - SyncDiseasesCatalogUseCase para gestionar la lógica de sincronización según el estado de la base de datos o memoria.
4. **Presentación**:
   - Integración de la llamada de sincronización en SplashViewModel durante la pantalla de carga de la aplicación.
5. **Calidad y Herramientas**:
   - Modificación de la configuración de Detekt para aplicar Compose Rules en todos los subproyectos y evitar errores de validación.
   - Actualización del archivo de dependencias de Javascript (yarn.lock).

Fixes #153