### PR TITLE
feat(canvas): mostrar icono sobre el nodo de una persona que tenga enfermedades (#150)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -28,7 +28,7 @@ val appName = "dev.saragones3.genogramia"
 val versionMajor = 1
 val versionMinor = 1
 val versionPatch = 0
-val versionBuild = 0
+val versionBuild = 1
 
 kotlin {
     applyHierarchyTemplate {

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/remote/Mapper.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/remote/Mapper.kt
@@ -1,43 +1,23 @@
 package dev.saragones3.genogramia.data.remote
 
-import dev.saragones3.genogramia.data.remote.model.DiseaseDto
 import dev.saragones3.genogramia.data.remote.model.GenogramTreeDto
 import dev.saragones3.genogramia.data.remote.model.MedicalConditionDto
 import dev.saragones3.genogramia.data.remote.model.PersonDto
 import dev.saragones3.genogramia.data.remote.model.RelationshipDto
-import dev.saragones3.genogramia.domain.model.Disease
 import dev.saragones3.genogramia.domain.model.GenogramTree
 import dev.saragones3.genogramia.domain.model.MedicalCondition
 import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.model.Relationship
 
-fun Disease.toDto() =
-    DiseaseDto(
-        code = code,
-        title = title,
-        chapterCode = chapterCode,
-        chapterTitle = chapterTitle,
-        isGenetic = isGenetic,
-    )
-
-fun DiseaseDto.toDomain() =
-    Disease(
-        code = code,
-        title = title,
-        chapterCode = chapterCode,
-        chapterTitle = chapterTitle,
-        isGenetic = isGenetic,
-    )
-
 fun MedicalCondition.toDto() =
     MedicalConditionDto(
-        disease = disease.toDto(),
+        diseaseCode = diseaseCode,
         diagnosisDate = diagnosisDate,
     )
 
 fun MedicalConditionDto.toDomain() =
     MedicalCondition(
-        disease = disease.toDomain(),
+        diseaseCode = diseaseCode,
         diagnosisDate = diagnosisDate,
     )
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/remote/model/FirestoreDto.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/remote/model/FirestoreDto.kt
@@ -2,22 +2,11 @@ package dev.saragones3.genogramia.data.remote.model
 
 import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.model.Relationship
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class DiseaseDto(
-    val code: String = "",
-    val title: String = "",
-    val chapterCode: String = "",
-    val chapterTitle: String = "",
-    @SerialName("genetic")
-    val isGenetic: Boolean = false,
-)
-
-@Serializable
 data class MedicalConditionDto(
-    val disease: DiseaseDto = DiseaseDto(),
+    val diseaseCode: String = "",
     val diagnosisDate: Long? = null,
 )
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/repository/InMemoryDiseaseRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/data/repository/InMemoryDiseaseRepository.kt
@@ -21,6 +21,8 @@ class InMemoryDiseaseRepository(
             }
     }
 
+    override suspend fun getDiseaseByCode(code: String): Disease? = cache.values.flatten().find { it.code == code }
+
     override suspend fun syncCatalog() {
         remoteDataSource.getChapters().forEach { chapterCode ->
             try {

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/di/DIConfig.kt
@@ -15,6 +15,7 @@ import dev.saragones3.genogramia.domain.usecase.DeleteAccountUseCase
 import dev.saragones3.genogramia.domain.usecase.DeletePersonUseCase
 import dev.saragones3.genogramia.domain.usecase.DeleteRelationshipUseCase
 import dev.saragones3.genogramia.domain.usecase.DeleteTreeUseCase
+import dev.saragones3.genogramia.domain.usecase.GetDiseaseByCodeUseCase
 import dev.saragones3.genogramia.domain.usecase.GetPersonUseCase
 import dev.saragones3.genogramia.domain.usecase.GetTreeUseCase
 import dev.saragones3.genogramia.domain.usecase.GetTreesUseCase
@@ -137,6 +138,7 @@ private val domainModule =
         factoryOf(::GetTreesUseCase)
         factoryOf(::GetTreeUseCase)
         factoryOf(::SearchDiseasesUseCase)
+        factoryOf(::GetDiseaseByCodeUseCase)
         factoryOf(::SyncDiseasesCatalogUseCase)
         factoryOf(::DateFormatter)
     }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/model/MedicalCondition.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/model/MedicalCondition.kt
@@ -1,6 +1,6 @@
 package dev.saragones3.genogramia.domain.model
 
 data class MedicalCondition(
-    val disease: Disease,
+    val diseaseCode: String,
     val diagnosisDate: Long? = null,
 )

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/repository/DiseaseRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/repository/DiseaseRepository.kt
@@ -7,5 +7,7 @@ interface DiseaseRepository {
 
     suspend fun searchDiseases(query: String): List<Disease>
 
+    suspend fun getDiseaseByCode(code: String): Disease?
+
     suspend fun syncCatalog()
 }

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/GetDiseaseByCodeUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/domain/usecase/GetDiseaseByCodeUseCase.kt
@@ -1,0 +1,10 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.Disease
+import dev.saragones3.genogramia.domain.repository.DiseaseRepository
+
+class GetDiseaseByCodeUseCase(
+    private val repository: DiseaseRepository,
+) {
+    suspend operator fun invoke(code: String): Disease? = repository.getDiseaseByCode(code)
+}

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModel.kt
@@ -2,10 +2,10 @@ package dev.saragones3.genogramia.presentation.addperson
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import dev.saragones3.genogramia.domain.model.Disease
 import dev.saragones3.genogramia.domain.model.MedicalCondition
 import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.usecase.AddPersonUseCase
+import dev.saragones3.genogramia.domain.usecase.GetDiseaseByCodeUseCase
 import dev.saragones3.genogramia.domain.usecase.GetPersonUseCase
 import dev.saragones3.genogramia.domain.usecase.SearchDiseasesUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdatePersonUseCase
@@ -24,6 +24,7 @@ class AddPersonViewModel(
     private val updatePersonUseCase: UpdatePersonUseCase,
     private val getPersonUseCase: GetPersonUseCase,
     private val searchDiseasesUseCase: SearchDiseasesUseCase,
+    private val getDiseaseByCodeUseCase: GetDiseaseByCodeUseCase,
     private val dateFormatter: DateFormatter,
 ) : ViewModel() {
     private val _state = MutableStateFlow(AddPersonState())
@@ -344,12 +345,13 @@ class AddPersonViewModel(
                                     } ?: "",
                                 medicalHistory =
                                     person.medicalHistory.map { condition ->
+                                        val disease = getDiseaseByCodeUseCase(condition.diseaseCode)
                                         MedicalConditionUi(
-                                            diseaseCode = condition.disease.code,
-                                            diseaseTitle = condition.disease.title,
-                                            chapterCode = condition.disease.chapterCode,
-                                            chapterTitle = condition.disease.chapterTitle,
-                                            isGenetic = condition.disease.isGenetic,
+                                            diseaseCode = condition.diseaseCode,
+                                            diseaseTitle = disease?.title ?: condition.diseaseCode,
+                                            chapterCode = disease?.chapterCode ?: "",
+                                            chapterTitle = disease?.chapterTitle ?: "",
+                                            isGenetic = disease?.isGenetic ?: false,
                                             diagnosisDateMillis = condition.diagnosisDate,
                                             diagnosisDateText =
                                                 condition.diagnosisDate?.let { date ->
@@ -421,14 +423,7 @@ class AddPersonViewModel(
                 medicalHistory =
                     personUi.medicalHistory.map { condition ->
                         MedicalCondition(
-                            disease =
-                                Disease(
-                                    code = condition.diseaseCode,
-                                    title = condition.diseaseTitle,
-                                    chapterCode = condition.chapterCode,
-                                    chapterTitle = condition.chapterTitle,
-                                    isGenetic = condition.isGenetic,
-                                ),
+                            diseaseCode = condition.diseaseCode,
                             diagnosisDate = condition.diagnosisDateMillis,
                         )
                     },

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/newtree/NewTreeViewModel.kt
@@ -2,7 +2,6 @@ package dev.saragones3.genogramia.presentation.newtree
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import dev.saragones3.genogramia.domain.model.Disease
 import dev.saragones3.genogramia.domain.model.MedicalCondition
 import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.usecase.CheckSessionUseCase
@@ -330,14 +329,7 @@ class NewTreeViewModel(
                     medicalHistory =
                         personUi.medicalHistory.map { condition ->
                             MedicalCondition(
-                                disease =
-                                    Disease(
-                                        code = condition.diseaseCode,
-                                        title = condition.diseaseTitle,
-                                        chapterCode = condition.chapterCode,
-                                        chapterTitle = condition.chapterTitle,
-                                        isGenetic = condition.isGenetic,
-                                    ),
+                                diseaseCode = condition.diseaseCode,
                                 diagnosisDate = condition.diagnosisDateMillis,
                             )
                         },

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.FilterCenterFocus
+import androidx.compose.material.icons.filled.MedicalServices
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -833,13 +834,29 @@ private fun PersonNodeView(
 
         Spacer(modifier = Modifier.height(4.dp))
 
-        PersonShape(
-            person = person,
-            shape = shape,
-            backgroundColor = backgroundColor,
-            size = with(density) { NODE_SIZE.toPx() },
-            modifier = nodeModifier,
-        )
+        Box(contentAlignment = Alignment.Center) {
+            PersonShape(
+                person = person,
+                shape = shape,
+                backgroundColor = backgroundColor,
+                size = with(density) { NODE_SIZE.toPx() },
+                modifier = nodeModifier,
+            )
+
+            if (person.hasMedicalHistory) {
+                Icon(
+                    imageVector = Icons.Default.MedicalServices,
+                    contentDescription = null,
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopEnd)
+                            .size(24.dp)
+                            .background(MaterialTheme.colorScheme.secondary, CircleShape)
+                            .padding(4.dp),
+                    tint = MaterialTheme.colorScheme.onSecondary,
+                )
+            }
+        }
 
         Spacer(modifier = Modifier.height(24.dp))
 
@@ -1055,6 +1072,7 @@ private class TreeStateProvider : PreviewParameterProvider<TreeState> {
                     birthDateText = "1980",
                     age = "44",
                     isIndexPerson = true,
+                    hasMedicalHistory = true,
                     position = Offset(100f, 100f),
                 ),
             persons =

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeUi.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeUi.kt
@@ -23,6 +23,7 @@ data class PersonNodeUi(
     val age: String = "",
     val isDeceased: Boolean = false,
     val isIndexPerson: Boolean = false,
+    val hasMedicalHistory: Boolean = false,
     val position: Offset = Offset.Zero,
 )
 

--- a/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModel.kt
@@ -507,6 +507,7 @@ class TreeViewModel(
             deathDateText = deathYear,
             age = age,
             isDeceased = deathDate != null,
+            hasMedicalHistory = medicalHistory.isNotEmpty(),
             position = Offset(x, y),
         )
     }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/GetDiseaseByCodeUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/GetDiseaseByCodeUseCaseTest.kt
@@ -1,0 +1,42 @@
+package dev.saragones3.genogramia.domain.usecase
+
+import dev.saragones3.genogramia.domain.model.Disease
+import dev.saragones3.genogramia.fakes.FakeDiseaseRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GetDiseaseByCodeUseCaseTest {
+    private val repository = FakeDiseaseRepository()
+    private val useCase = GetDiseaseByCodeUseCase(repository)
+
+    private val disease =
+        Disease(
+            code = "BA00",
+            title = "Hypertension",
+            chapterCode = "11",
+            chapterTitle = "Circulatory System",
+            isGenetic = false,
+        )
+
+    @Test
+    fun `GIVEN a code WHEN disease exists THEN returns the disease`() =
+        runTest {
+            repository.diseases = listOf(disease)
+
+            val result = useCase("BA00")
+
+            assertEquals(disease, result)
+        }
+
+    @Test
+    fun `GIVEN a code WHEN disease does not exist THEN returns null`() =
+        runTest {
+            repository.diseases = listOf(disease)
+
+            val result = useCase("INVALID")
+
+            assertNull(result)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/UpdatePersonUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/domain/usecase/UpdatePersonUseCaseTest.kt
@@ -1,6 +1,5 @@
 package dev.saragones3.genogramia.domain.usecase
 
-import dev.saragones3.genogramia.domain.model.Disease
 import dev.saragones3.genogramia.domain.model.GenogramTree
 import dev.saragones3.genogramia.domain.model.MedicalCondition
 import dev.saragones3.genogramia.domain.model.Person
@@ -67,8 +66,8 @@ class UpdatePersonUseCaseTest {
     fun `GIVEN central person WHEN updating medical history THEN medical history is updated`() =
         runTest {
             repository.createTree(tree)
-            val disease = Disease("BA00", "Hypertension", "11", "Circulatory System", false)
-            val medicalCondition = MedicalCondition(disease, 1778716800000L)
+            val diseaseCode = "BA00"
+            val medicalCondition = MedicalCondition(diseaseCode, 1778716800000L)
             val updatedPerson = centralPerson.copy(medicalHistory = listOf(medicalCondition))
 
             val result = useCase("tree-1", updatedPerson)
@@ -77,12 +76,12 @@ class UpdatePersonUseCaseTest {
             val updatedTree = repository.getTree("tree-1")
             assertEquals(1, updatedTree?.centralPerson?.medicalHistory?.size)
             assertEquals(
-                disease,
+                diseaseCode,
                 updatedTree
                     ?.centralPerson
                     ?.medicalHistory
                     ?.first()
-                    ?.disease,
+                    ?.diseaseCode,
             )
         }
 

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeDiseaseRepository.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/fakes/FakeDiseaseRepository.kt
@@ -15,6 +15,8 @@ class FakeDiseaseRepository : DiseaseRepository {
 
     override suspend fun searchDiseases(query: String): List<Disease> = diseases.filter { it.title.contains(query) }
 
+    override suspend fun getDiseaseByCode(code: String): Disease? = diseases.find { it.code == code }
+
     override suspend fun syncCatalog() {
         synced = true
     }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/addperson/AddPersonViewModelTest.kt
@@ -5,6 +5,7 @@ import dev.saragones3.genogramia.domain.model.Disease
 import dev.saragones3.genogramia.domain.model.GenogramTree
 import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.usecase.AddPersonUseCase
+import dev.saragones3.genogramia.domain.usecase.GetDiseaseByCodeUseCase
 import dev.saragones3.genogramia.domain.usecase.GetPersonUseCase
 import dev.saragones3.genogramia.domain.usecase.SearchDiseasesUseCase
 import dev.saragones3.genogramia.domain.usecase.UpdatePersonUseCase
@@ -40,6 +41,7 @@ class AddPersonViewModelTest {
     private val updatePersonUseCase = UpdatePersonUseCase(treeRepository, fakeDateProvider, dateFormatter)
     private val getPersonUseCase = GetPersonUseCase(treeRepository)
     private val searchDiseasesUseCase = SearchDiseasesUseCase(diseaseRepository)
+    private val getDiseaseByCodeUseCase = GetDiseaseByCodeUseCase(diseaseRepository)
     private lateinit var viewModel: AddPersonViewModel
 
     private val tree =
@@ -76,6 +78,7 @@ class AddPersonViewModelTest {
                 updatePersonUseCase,
                 getPersonUseCase,
                 searchDiseasesUseCase,
+                getDiseaseByCodeUseCase,
                 dateFormatter,
             )
     }

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
@@ -2,7 +2,9 @@ package dev.saragones3.genogramia.presentation.tree
 
 import androidx.compose.ui.geometry.Offset
 import app.cash.turbine.test
+import dev.saragones3.genogramia.domain.model.Disease
 import dev.saragones3.genogramia.domain.model.GenogramTree
+import dev.saragones3.genogramia.domain.model.MedicalCondition
 import dev.saragones3.genogramia.domain.model.Person
 import dev.saragones3.genogramia.domain.model.Relationship
 import dev.saragones3.genogramia.domain.usecase.DeletePersonUseCase
@@ -134,6 +136,7 @@ class TreeViewModelTest {
             assertEquals("1989", centralPerson.deathDateText)
             assertEquals("74", centralPerson.age)
             assertEquals(true, centralPerson.isDeceased)
+            assertEquals(false, centralPerson.hasMedicalHistory)
         }
 
     @Test
@@ -143,8 +146,33 @@ class TreeViewModelTest {
             dateProvider.currentTimeMillis = 1704067200000L // 2024-01-01
 
             // 1980-01-01
-            val person = Person("p1", "John", "Doe", birthDate = 315532800000L)
-            val tree = GenogramTree("t1", 1, "now", person)
+            val person =
+                Person(
+                    id = "p1",
+                    firstName = "John",
+                    lastName = "Doe",
+                    birthDate = 315532800000L,
+                    medicalHistory =
+                        listOf(
+                            MedicalCondition(
+                                disease =
+                                    Disease(
+                                        code = "d1",
+                                        title = "Diabetes",
+                                        chapterCode = "c1",
+                                        chapterTitle = "Chapter 1",
+                                        isGenetic = false,
+                                    ),
+                            ),
+                        ),
+                )
+            val tree =
+                GenogramTree(
+                    id = "t1",
+                    ancestorCount = 1,
+                    lastUpdated = "now",
+                    centralPerson = person,
+                )
             treeRepository.createTree(tree)
 
             viewModel.onEvent(TreeEvent.LoadTree("t1"))
@@ -156,6 +184,7 @@ class TreeViewModelTest {
             assertEquals("", centralPerson.deathDateText)
             assertEquals("44", centralPerson.age)
             assertEquals(false, centralPerson.isDeceased)
+            assertEquals(true, centralPerson.hasMedicalHistory)
         }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/saragones3/genogramia/presentation/tree/TreeViewModelTest.kt
@@ -2,7 +2,6 @@ package dev.saragones3.genogramia.presentation.tree
 
 import androidx.compose.ui.geometry.Offset
 import app.cash.turbine.test
-import dev.saragones3.genogramia.domain.model.Disease
 import dev.saragones3.genogramia.domain.model.GenogramTree
 import dev.saragones3.genogramia.domain.model.MedicalCondition
 import dev.saragones3.genogramia.domain.model.Person
@@ -155,14 +154,7 @@ class TreeViewModelTest {
                     medicalHistory =
                         listOf(
                             MedicalCondition(
-                                disease =
-                                    Disease(
-                                        code = "d1",
-                                        title = "Diabetes",
-                                        chapterCode = "c1",
-                                        chapterTitle = "Chapter 1",
-                                        isGenetic = false,
-                                    ),
+                                diseaseCode = "d1",
                             ),
                         ),
                 )

--- a/composeApp/src/mobileMain/kotlin/dev/saragones3/genogramia/data/repository/RoomDiseaseRepository.kt
+++ b/composeApp/src/mobileMain/kotlin/dev/saragones3/genogramia/data/repository/RoomDiseaseRepository.kt
@@ -19,6 +19,8 @@ class RoomDiseaseRepository(
 
     override suspend fun searchDiseases(query: String): List<Disease> = dao.searchDiseases(query).map { it.toDomain() }
 
+    override suspend fun getDiseaseByCode(code: String): Disease? = dao.getDiseaseByCode(code)?.toDomain()
+
     override suspend fun syncCatalog() {
         val currentLanguage = getAppLanguage()
         remoteDataSource.getChapters().forEach { chapterCode ->

--- a/composeApp/src/mobileMain/kotlin/dev/saragones3/genogramia/data/repository/RoomDiseaseRepository.kt
+++ b/composeApp/src/mobileMain/kotlin/dev/saragones3/genogramia/data/repository/RoomDiseaseRepository.kt
@@ -1,12 +1,12 @@
 package dev.saragones3.genogramia.data.repository
 
 import dev.saragones3.genogramia.core.database.DiseaseDao
-import dev.saragones3.genogramia.core.database.model.ChapterSyncEntity
 import dev.saragones3.genogramia.core.database.model.DiseaseEntity
 import dev.saragones3.genogramia.data.remote.DiseasesRemoteDataSource
 import dev.saragones3.genogramia.data.remote.toDomainList
 import dev.saragones3.genogramia.domain.model.Disease
 import dev.saragones3.genogramia.domain.repository.DiseaseRepository
+import dev.saragones3.genogramia.util.getAppLanguage
 
 class RoomDiseaseRepository(
     private val remoteDataSource: DiseasesRemoteDataSource,
@@ -20,19 +20,22 @@ class RoomDiseaseRepository(
     override suspend fun searchDiseases(query: String): List<Disease> = dao.searchDiseases(query).map { it.toDomain() }
 
     override suspend fun syncCatalog() {
+        val currentLanguage = getAppLanguage()
         remoteDataSource.getChapters().forEach { chapterCode ->
             try {
                 val localSync = dao.getChapterSync(chapterCode)
                 val chapterDto = remoteDataSource.getChapter(chapterCode)
 
                 val localSyncDate = localSync?.lastSyncDate
+                val localLanguage = localSync?.language
                 val remoteSyncDate = chapterDto.lastSync
 
-                if (remoteSyncDate != localSyncDate) {
+                if (remoteSyncDate != localSyncDate || currentLanguage != localLanguage) {
                     val diseases = chapterDto.toDomainList()
                     dao.replaceChapterData(
                         chapterCode = chapterCode,
                         lastSyncDate = remoteSyncDate,
+                        language = currentLanguage,
                         diseases = diseases.map { it.toEntity() },
                     )
                 }

--- a/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/DiseaseDao.kt
+++ b/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/DiseaseDao.kt
@@ -34,10 +34,11 @@ interface DiseaseDao {
     suspend fun replaceChapterData(
         chapterCode: String,
         lastSyncDate: String,
+        language: String,
         diseases: List<DiseaseEntity>,
     ) {
         deleteDiseasesByChapter(chapterCode)
         insertDiseases(diseases)
-        insertChapterSync(ChapterSyncEntity(chapterCode, lastSyncDate))
+        insertChapterSync(ChapterSyncEntity(chapterCode, lastSyncDate, language))
     }
 }

--- a/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/DiseaseDao.kt
+++ b/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/DiseaseDao.kt
@@ -18,6 +18,9 @@ interface DiseaseDao {
     )
     suspend fun searchDiseases(query: String): List<DiseaseEntity>
 
+    @Query("SELECT * FROM disease WHERE code = :code")
+    suspend fun getDiseaseByCode(code: String): DiseaseEntity?
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertDiseases(diseases: List<DiseaseEntity>)
 

--- a/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/GenogramiaDatabase.kt
+++ b/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/GenogramiaDatabase.kt
@@ -10,7 +10,7 @@ import dev.saragones3.genogramia.core.database.model.DiseaseEntity
         DiseaseEntity::class,
         ChapterSyncEntity::class,
     ],
-    version = 1,
+    version = 2,
 )
 abstract class GenogramiaDatabase : RoomDatabase() {
     abstract fun diseaseDao(): DiseaseDao

--- a/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/di/DatabaseModule.kt
+++ b/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/di/DatabaseModule.kt
@@ -1,6 +1,9 @@
 package dev.saragones3.genogramia.core.database.di
 
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
 import dev.saragones3.genogramia.core.database.DiseaseDao
 import dev.saragones3.genogramia.core.database.GenogramiaDatabase
 import org.koin.core.qualifier.named
@@ -8,13 +11,21 @@ import org.koin.dsl.module
 
 private const val DATABASE_NAME = "GenogramIA"
 
+private val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL("ALTER TABLE chapter_sync ADD language TEXT NOT NULL DEFAULT en")
+    }
+}
+
 val databaseModule =
     module {
         includes(platformModule)
         single<String>(named("database_name")) { DATABASE_NAME }
         single<GenogramiaDatabase> {
             val builder = get<RoomDatabase.Builder<GenogramiaDatabase>>()
-            builder.build()
+            builder
+                .addMigrations(MIGRATION_1_2)
+                .build()
         }
         single<DiseaseDao> { get<GenogramiaDatabase>().diseaseDao() }
     }

--- a/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/model/ChapterSyncEntity.kt
+++ b/core/database/src/commonMain/kotlin/dev/saragones3/genogramia/core/database/model/ChapterSyncEntity.kt
@@ -8,4 +8,5 @@ data class ChapterSyncEntity(
     @PrimaryKey
     val chapterCode: String,
     val lastSyncDate: String,
+    val language: String,
 )

--- a/whatsnew/whatsnew-es_ES
+++ b/whatsnew/whatsnew-es_ES
@@ -1,1 +1,2 @@
-- Redibujadas líneas entre personas para adaptarlas a la realidad de un genograma.
+- Implementada funcionalidad para añadir enfermedades a una persona.
+- Añadido marcador sobre el nodo de una persona en el árbol para indicar si tiene alguna enfermedad.


### PR DESCRIPTION
Fixes #150. \n\n### Cambios realizados:\n- Se ha implementado la detección de enfermedades en el historial médico de las personas al renderizar sus nodos en el canvas.\n- Se ha añadido un icono visual (cruz médica) que aparece sobre el nodo de la persona si tiene al menos una enfermedad registrada.\n- El icono se ha diseñado siguiendo el sistema de diseño del proyecto, asegurando visibilidad y sutileza.\n- Se ha garantizado la reactividad del icono ante cambios en el historial de enfermedades.